### PR TITLE
Add replay recording support

### DIFF
--- a/osu.Game.Rulesets.Rush.Tests/Replay/RushReplayFrameTest.cs
+++ b/osu.Game.Rulesets.Rush.Tests/Replay/RushReplayFrameTest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Rush.Replays;
+
+namespace osu.Game.Rulesets.Rush.Tests.Replay
+{
+    [TestFixture]
+    public class RushReplayFrameTest
+    {
+        [TestCase]
+        [TestCase(RushAction.AirPrimary, RushAction.GroundPrimary)]
+        [TestCase(RushAction.AirPrimary, RushAction.AirSecondary, RushAction.GroundQuaternary)]
+        [TestCase(RushAction.GroundPrimary, RushAction.GroundSecondary)]
+        [TestCase(RushAction.AirPrimary, RushAction.AirSecondary, RushAction.AirTertiary, RushAction.AirQuaternary, RushAction.GroundPrimary, RushAction.GroundSecondary, RushAction.GroundTertiary, RushAction.GroundTertiary)]
+        public void TestParity(params RushAction[] actions)
+        {
+            var originalFrame = (RushReplayFrame)new RushRuleset().CreateConvertibleReplayFrame();
+            var resultFrame = (RushReplayFrame)new RushRuleset().CreateConvertibleReplayFrame();
+
+            resultFrame.FromLegacy(originalFrame.ToLegacy(new Beatmap()), new Beatmap());
+
+            Assert.That(resultFrame.Actions, Is.EquivalentTo(originalFrame.Actions));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Game.Beatmaps;
@@ -35,16 +36,14 @@ namespace osu.Game.Rulesets.Rush.Replays
 
         public void FromLegacy(LegacyReplayFrame currentFrame, IBeatmap beatmap, ReplayFrame lastFrame = null)
         {
-            if (currentFrame.MouseLeft1) Actions.Add(RushAction.AirPrimary);
-            if (currentFrame.MouseLeft2) Actions.Add(RushAction.AirSecondary);
-            if (currentFrame.MouseRight1) Actions.Add(RushAction.GroundPrimary);
-            if (currentFrame.MouseRight2) Actions.Add(RushAction.GroundSecondary);
-
-            if (currentFrame.MouseX != null)
-                Actions.AddRange(getActionsFromFlags((RushActionFlags)currentFrame.MouseX));
+            Debug.Assert(currentFrame.MouseX != null);
+            Actions.AddRange(getActionsFromFlags((RushActionFlags)currentFrame.MouseX));
         }
 
-        public LegacyReplayFrame ToLegacy(IBeatmap beatmap) => new LegacyReplayFrame(Time, (float)getFlagsFromActions(Actions), 0f, ReplayButtonState.None);
+        public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
+        {
+            return new LegacyReplayFrame(Time, (float)getFlagsFromActions(Actions), 0f, ReplayButtonState.None);
+        }
 
         private static RushActionFlags getFlagsFromActions(IEnumerable<RushAction> actions)
         {

--- a/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
@@ -51,9 +51,9 @@ namespace osu.Game.Rulesets.Rush.Replays
 
         public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
         {
-            int flags = 0;
+            uint flags = 0;
             foreach (var action in Actions)
-                flags |= 1 << (int)action;
+                flags |= 1u << (int)action;
 
             return new LegacyReplayFrame(Time, flags, 0f, ReplayButtonState.None);
         }

--- a/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
@@ -41,47 +41,49 @@ namespace osu.Game.Rulesets.Rush.Replays
             if (currentFrame.MouseRight2) Actions.Add(RushAction.GroundSecondary);
 
             if (currentFrame.MouseX != null)
-                Actions.AddRange(getActionsFromFlags((RushSideActionFlags)currentFrame.MouseX));
+                Actions.AddRange(getActionsFromFlags((RushActionFlags)currentFrame.MouseX));
         }
 
-        public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
+        public LegacyReplayFrame ToLegacy(IBeatmap beatmap) => new LegacyReplayFrame(Time, (float)getFlagsFromActions(Actions), 0f, ReplayButtonState.None);
+
+        private static RushActionFlags getFlagsFromActions(IEnumerable<RushAction> actions)
         {
-            ReplayButtonState state = ReplayButtonState.None;
+            RushActionFlags flags = RushActionFlags.None;
 
-            if (Actions.Contains(RushAction.AirPrimary)) state |= ReplayButtonState.Left1;
-            if (Actions.Contains(RushAction.AirSecondary)) state |= ReplayButtonState.Left2;
-            if (Actions.Contains(RushAction.GroundPrimary)) state |= ReplayButtonState.Right1;
-            if (Actions.Contains(RushAction.GroundSecondary)) state |= ReplayButtonState.Right2;
-
-            return new LegacyReplayFrame(Time, (float)getFlagsFromActions(Actions), 0f, state);
-        }
-
-        private static RushSideActionFlags getFlagsFromActions(IEnumerable<RushAction> actions)
-        {
-            RushSideActionFlags flags = RushSideActionFlags.None;
-
-            if (actions.Contains(RushAction.AirTertiary)) flags |= RushSideActionFlags.AirTertiary;
-            if (actions.Contains(RushAction.AirQuaternary)) flags |= RushSideActionFlags.AirQuaternary;
-            if (actions.Contains(RushAction.GroundTertiary)) flags |= RushSideActionFlags.GroundTertiary;
-            if (actions.Contains(RushAction.GroundQuaternary)) flags |= RushSideActionFlags.GroundQuaternary;
+            if (actions.Contains(RushAction.AirPrimary)) flags |= RushActionFlags.AirPrimary;
+            if (actions.Contains(RushAction.AirSecondary)) flags |= RushActionFlags.AirSecondary;
+            if (actions.Contains(RushAction.AirTertiary)) flags |= RushActionFlags.AirTertiary;
+            if (actions.Contains(RushAction.AirQuaternary)) flags |= RushActionFlags.AirQuaternary;
+            if (actions.Contains(RushAction.GroundPrimary)) flags |= RushActionFlags.GroundPrimary;
+            if (actions.Contains(RushAction.GroundSecondary)) flags |= RushActionFlags.GroundSecondary;
+            if (actions.Contains(RushAction.GroundTertiary)) flags |= RushActionFlags.GroundTertiary;
+            if (actions.Contains(RushAction.GroundQuaternary)) flags |= RushActionFlags.GroundQuaternary;
 
             return flags;
         }
 
-        private static IEnumerable<RushAction> getActionsFromFlags(RushSideActionFlags sideFlags)
+        private static IEnumerable<RushAction> getActionsFromFlags(RushActionFlags flags)
         {
-            if (sideFlags.HasFlagFast(RushSideActionFlags.AirTertiary)) yield return RushAction.AirTertiary;
-            if (sideFlags.HasFlagFast(RushSideActionFlags.AirQuaternary)) yield return RushAction.AirQuaternary;
-            if (sideFlags.HasFlagFast(RushSideActionFlags.GroundTertiary)) yield return RushAction.GroundTertiary;
-            if (sideFlags.HasFlagFast(RushSideActionFlags.GroundQuaternary)) yield return RushAction.GroundQuaternary;
+            if (flags.HasFlagFast(RushActionFlags.AirPrimary)) yield return RushAction.AirPrimary;
+            if (flags.HasFlagFast(RushActionFlags.AirSecondary)) yield return RushAction.AirSecondary;
+            if (flags.HasFlagFast(RushActionFlags.AirTertiary)) yield return RushAction.AirTertiary;
+            if (flags.HasFlagFast(RushActionFlags.AirQuaternary)) yield return RushAction.AirQuaternary;
+            if (flags.HasFlagFast(RushActionFlags.GroundPrimary)) yield return RushAction.GroundPrimary;
+            if (flags.HasFlagFast(RushActionFlags.GroundSecondary)) yield return RushAction.GroundSecondary;
+            if (flags.HasFlagFast(RushActionFlags.GroundTertiary)) yield return RushAction.GroundTertiary;
+            if (flags.HasFlagFast(RushActionFlags.GroundQuaternary)) yield return RushAction.GroundQuaternary;
         }
 
         [Flags]
-        private enum RushSideActionFlags
+        private enum RushActionFlags
         {
             None = 0,
+            AirPrimary = 1 << 0,
+            AirSecondary = 1 << 1,
             AirTertiary = 1 << 2,
             AirQuaternary = 1 << 3,
+            GroundPrimary = 1 << 4,
+            GroundSecondary = 1 << 5,
             GroundTertiary = 1 << 6,
             GroundQuaternary = 1 << 7,
         }

--- a/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
@@ -2,11 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Replays.Types;
 
 namespace osu.Game.Rulesets.Rush.Replays
 {
-    public class RushReplayFrame : ReplayFrame
+    public class RushReplayFrame : ReplayFrame, IConvertibleReplayFrame
     {
         public List<RushAction> Actions = new List<RushAction>();
 
@@ -25,6 +28,33 @@ namespace osu.Game.Rulesets.Rush.Replays
             : base(time)
         {
             Actions.AddRange(buttons);
+        }
+
+        public void FromLegacy(LegacyReplayFrame currentFrame, IBeatmap beatmap, ReplayFrame lastFrame = null)
+        {
+            if (currentFrame.MouseLeft1) Actions.Add(RushAction.AirPrimary);
+            if (currentFrame.MouseLeft2) Actions.Add(RushAction.AirSecondary);
+            if (currentFrame.MouseRight1) Actions.Add(RushAction.GroundPrimary);
+            if (currentFrame.MouseRight2) Actions.Add(RushAction.GroundSecondary);
+        }
+
+        public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
+        {
+            ReplayButtonState state = ReplayButtonState.None;
+
+            if (Actions.Contains(RushAction.AirPrimary) || Actions.Contains(RushAction.AirTertiary))
+                state |= ReplayButtonState.Left1;
+
+            if (Actions.Contains(RushAction.AirSecondary) || Actions.Contains(RushAction.AirQuaternary))
+                state |= ReplayButtonState.Left2;
+
+            if (Actions.Contains(RushAction.GroundPrimary) || Actions.Contains(RushAction.GroundSecondary))
+                state |= ReplayButtonState.Right1;
+
+            if (Actions.Contains(RushAction.GroundTertiary) || Actions.Contains(RushAction.GroundQuaternary))
+                state |= ReplayButtonState.Right2;
+
+            return new LegacyReplayFrame(Time, 0f, 0f, state);
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using osu.Framework.Extensions.EnumExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Replays;
@@ -37,54 +34,28 @@ namespace osu.Game.Rulesets.Rush.Replays
         public void FromLegacy(LegacyReplayFrame currentFrame, IBeatmap beatmap, ReplayFrame lastFrame = null)
         {
             Debug.Assert(currentFrame.MouseX != null);
-            Actions.AddRange(getActionsFromFlags((RushActionFlags)currentFrame.MouseX));
+
+            uint flags = (uint)currentFrame.MouseX;
+
+            int currentBit = 0;
+
+            while (flags > 0)
+            {
+                if ((flags & 1) > 0)
+                    Actions.Add((RushAction)currentBit);
+
+                ++currentBit;
+                flags >>= 1;
+            }
         }
 
         public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
         {
-            return new LegacyReplayFrame(Time, (float)getFlagsFromActions(Actions), 0f, ReplayButtonState.None);
-        }
+            int flags = 0;
+            foreach (var action in Actions)
+                flags |= 1 << (int)action;
 
-        private static RushActionFlags getFlagsFromActions(IEnumerable<RushAction> actions)
-        {
-            RushActionFlags flags = RushActionFlags.None;
-
-            if (actions.Contains(RushAction.AirPrimary)) flags |= RushActionFlags.AirPrimary;
-            if (actions.Contains(RushAction.AirSecondary)) flags |= RushActionFlags.AirSecondary;
-            if (actions.Contains(RushAction.AirTertiary)) flags |= RushActionFlags.AirTertiary;
-            if (actions.Contains(RushAction.AirQuaternary)) flags |= RushActionFlags.AirQuaternary;
-            if (actions.Contains(RushAction.GroundPrimary)) flags |= RushActionFlags.GroundPrimary;
-            if (actions.Contains(RushAction.GroundSecondary)) flags |= RushActionFlags.GroundSecondary;
-            if (actions.Contains(RushAction.GroundTertiary)) flags |= RushActionFlags.GroundTertiary;
-            if (actions.Contains(RushAction.GroundQuaternary)) flags |= RushActionFlags.GroundQuaternary;
-
-            return flags;
-        }
-
-        private static IEnumerable<RushAction> getActionsFromFlags(RushActionFlags flags)
-        {
-            if (flags.HasFlagFast(RushActionFlags.AirPrimary)) yield return RushAction.AirPrimary;
-            if (flags.HasFlagFast(RushActionFlags.AirSecondary)) yield return RushAction.AirSecondary;
-            if (flags.HasFlagFast(RushActionFlags.AirTertiary)) yield return RushAction.AirTertiary;
-            if (flags.HasFlagFast(RushActionFlags.AirQuaternary)) yield return RushAction.AirQuaternary;
-            if (flags.HasFlagFast(RushActionFlags.GroundPrimary)) yield return RushAction.GroundPrimary;
-            if (flags.HasFlagFast(RushActionFlags.GroundSecondary)) yield return RushAction.GroundSecondary;
-            if (flags.HasFlagFast(RushActionFlags.GroundTertiary)) yield return RushAction.GroundTertiary;
-            if (flags.HasFlagFast(RushActionFlags.GroundQuaternary)) yield return RushAction.GroundQuaternary;
-        }
-
-        [Flags]
-        private enum RushActionFlags
-        {
-            None = 0,
-            AirPrimary = 1 << 0,
-            AirSecondary = 1 << 1,
-            AirTertiary = 1 << 2,
-            AirQuaternary = 1 << 3,
-            GroundPrimary = 1 << 4,
-            GroundSecondary = 1 << 5,
-            GroundTertiary = 1 << 6,
-            GroundQuaternary = 1 << 7,
+            return new LegacyReplayFrame(Time, flags, 0f, ReplayButtonState.None);
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Replays;
@@ -36,25 +39,51 @@ namespace osu.Game.Rulesets.Rush.Replays
             if (currentFrame.MouseLeft2) Actions.Add(RushAction.AirSecondary);
             if (currentFrame.MouseRight1) Actions.Add(RushAction.GroundPrimary);
             if (currentFrame.MouseRight2) Actions.Add(RushAction.GroundSecondary);
+
+            if (currentFrame.MouseX != null)
+                Actions.AddRange(getActionsFromFlags((RushSideActionFlags)currentFrame.MouseX));
         }
 
         public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
         {
             ReplayButtonState state = ReplayButtonState.None;
 
-            if (Actions.Contains(RushAction.AirPrimary) || Actions.Contains(RushAction.AirTertiary))
-                state |= ReplayButtonState.Left1;
+            if (Actions.Contains(RushAction.AirPrimary)) state |= ReplayButtonState.Left1;
+            if (Actions.Contains(RushAction.AirSecondary)) state |= ReplayButtonState.Left2;
+            if (Actions.Contains(RushAction.GroundPrimary)) state |= ReplayButtonState.Right1;
+            if (Actions.Contains(RushAction.GroundSecondary)) state |= ReplayButtonState.Right2;
 
-            if (Actions.Contains(RushAction.AirSecondary) || Actions.Contains(RushAction.AirQuaternary))
-                state |= ReplayButtonState.Left2;
+            return new LegacyReplayFrame(Time, (float)getFlagsFromActions(Actions), 0f, state);
+        }
 
-            if (Actions.Contains(RushAction.GroundPrimary) || Actions.Contains(RushAction.GroundSecondary))
-                state |= ReplayButtonState.Right1;
+        private static RushSideActionFlags getFlagsFromActions(IEnumerable<RushAction> actions)
+        {
+            RushSideActionFlags flags = RushSideActionFlags.None;
 
-            if (Actions.Contains(RushAction.GroundTertiary) || Actions.Contains(RushAction.GroundQuaternary))
-                state |= ReplayButtonState.Right2;
+            if (actions.Contains(RushAction.AirTertiary)) flags |= RushSideActionFlags.AirTertiary;
+            if (actions.Contains(RushAction.AirQuaternary)) flags |= RushSideActionFlags.AirQuaternary;
+            if (actions.Contains(RushAction.GroundTertiary)) flags |= RushSideActionFlags.GroundTertiary;
+            if (actions.Contains(RushAction.GroundQuaternary)) flags |= RushSideActionFlags.GroundQuaternary;
 
-            return new LegacyReplayFrame(Time, 0f, 0f, state);
+            return flags;
+        }
+
+        private static IEnumerable<RushAction> getActionsFromFlags(RushSideActionFlags sideFlags)
+        {
+            if (sideFlags.HasFlagFast(RushSideActionFlags.AirTertiary)) yield return RushAction.AirTertiary;
+            if (sideFlags.HasFlagFast(RushSideActionFlags.AirQuaternary)) yield return RushAction.AirQuaternary;
+            if (sideFlags.HasFlagFast(RushSideActionFlags.GroundTertiary)) yield return RushAction.GroundTertiary;
+            if (sideFlags.HasFlagFast(RushSideActionFlags.GroundQuaternary)) yield return RushAction.GroundQuaternary;
+        }
+
+        [Flags]
+        private enum RushSideActionFlags
+        {
+            None = 0,
+            AirTertiary = 1,
+            AirQuaternary = 2,
+            GroundTertiary = 4,
+            GroundQuaternary = 8,
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
@@ -80,10 +80,10 @@ namespace osu.Game.Rulesets.Rush.Replays
         private enum RushSideActionFlags
         {
             None = 0,
-            AirTertiary = 1,
-            AirQuaternary = 2,
-            GroundTertiary = 4,
-            GroundQuaternary = 8,
+            AirTertiary = 1 << 2,
+            AirQuaternary = 1 << 3,
+            GroundTertiary = 1 << 6,
+            GroundQuaternary = 1 << 7,
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/RushInputManager.cs
+++ b/osu.Game.Rulesets.Rush/RushInputManager.cs
@@ -25,28 +25,28 @@ namespace osu.Game.Rulesets.Rush
     public enum RushAction
     {
         [Description("Ground (Primary)")]
-        GroundPrimary,
+        GroundPrimary = 0,
 
         [Description("Ground (Secondary)")]
-        GroundSecondary,
+        GroundSecondary = 1,
 
         [Description("Ground (Tertiary)")]
-        GroundTertiary,
+        GroundTertiary = 2,
 
         [Description("Ground (Quaternary)")]
-        GroundQuaternary,
+        GroundQuaternary = 3,
 
         [Description("Air (Primary)")]
-        AirPrimary,
+        AirPrimary = 4,
 
         [Description("Air (Secondary)")]
-        AirSecondary,
+        AirSecondary = 5,
 
         [Description("Air (Tertiary)")]
-        AirTertiary,
+        AirTertiary = 6,
 
         [Description("Air (Quaternary)")]
-        AirQuaternary
+        AirQuaternary = 7
     }
 
     public static class RushActionExtensions

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -10,8 +10,10 @@ using osu.Framework.Input.Bindings;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Rush.Beatmaps;
 using osu.Game.Rulesets.Rush.Mods;
+using osu.Game.Rulesets.Rush.Replays;
 using osu.Game.Rulesets.Rush.Scoring;
 using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Scoring;
@@ -85,6 +87,8 @@ namespace osu.Game.Rulesets.Rush
             new KeyBinding(InputKey.MouseRight, RushAction.GroundPrimary),
             new KeyBinding(InputKey.MouseLeft, RushAction.AirPrimary),
         };
+
+        public override IConvertibleReplayFrame CreateConvertibleReplayFrame() => new RushReplayFrame();
 
         public override Drawable CreateIcon() => new RushIcon();
 

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -16,6 +16,7 @@ using osu.Game.Rulesets.Rush.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Replays;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Rush.UI
 {
@@ -38,6 +39,8 @@ namespace osu.Game.Rulesets.Rush.UI
         protected override Playfield CreatePlayfield() => new RushPlayfield();
 
         protected override ReplayInputHandler CreateReplayInputHandler(Replay replay) => new RushFramedReplayInputHandler(replay);
+
+        protected override ReplayRecorder CreateReplayRecorder(Score score) => new RushReplayRecorder(score);
 
         public new RushPlayfield Playfield => (RushPlayfield)base.Playfield;
 

--- a/osu.Game.Rulesets.Rush/UI/RushReplayRecorder.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushReplayRecorder.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Rush.Replays;
+using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
+using osuTK;
+
+namespace osu.Game.Rulesets.Rush.UI
+{
+    public class RushReplayRecorder : ReplayRecorder<RushAction>
+    {
+        public RushReplayRecorder(Score target)
+            : base(target)
+        {
+        }
+
+        protected override ReplayFrame HandleFrame(Vector2 mousePosition, List<RushAction> actions, ReplayFrame previousFrame)
+            => new RushReplayFrame(Time.Current, actions);
+    }
+}


### PR DESCRIPTION
Currently has to convert from and to legacy replay frames due to no modern replay encoding support osu!lazer-side yet, which limits tertiary and quaternary actions from being saved as-is in replays, but looks to be working as expected to for now.