### PR TITLE
Pool HitObjects, explosions and judgements

### DIFF
--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
@@ -22,6 +22,10 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         public DrawableDualHitPart Air => airHitContainer.Child;
         public DrawableDualHitPart Ground => groundHitContainer.Child;
 
+        public DrawableDualHit()
+        : this(null)
+        { }
+
         public DrawableDualHit(DualHit hitObject)
             : base(hitObject)
         {
@@ -51,8 +55,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         protected override void ClearNestedHitObjects()
         {
             base.ClearNestedHitObjects();
-            airHitContainer.Clear();
-            groundHitContainer.Clear();
+            airHitContainer.Clear(false);
+            groundHitContainer.Clear(false);
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
-using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
@@ -77,13 +75,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             base.UpdateInitialTransforms();
 
             skinnedJoin.Show();
-        }
-
-        protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)
-        {
-            base.OnDirectionChanged(e);
-
-            Origin = e.NewValue == ScrollingDirection.Left ? Anchor.CentreLeft : Anchor.CentreRight;
         }
 
         // Input are handled by the DualHit parts, since they still act like normal minions

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
@@ -24,8 +24,9 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         public override bool DisplayResult => false;
 
         public DrawableDualHit()
-        : this(null)
-        { }
+            : this(null)
+        {
+        }
 
         public DrawableDualHit(DualHit hitObject)
             : base(hitObject)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             AddRangeInternal(new Drawable[]
             {
                 skinnedJoin = new SkinnableDrawable(new RushSkinComponent(RushSkinComponents.DualHitJoin), _ => new DualHitJoinPiece()),
-                airHitContainer = new Container<DrawableDualHitPart> { RelativeSizeAxes = Axes.Both },
-                groundHitContainer = new Container<DrawableDualHitPart> { RelativeSizeAxes = Axes.Both },
+                airHitContainer = new Container<DrawableDualHitPart> { Anchor = Anchor.TopCentre },
+                groundHitContainer = new Container<DrawableDualHitPart> { Anchor = Anchor.BottomCentre },
             });
         }
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             RelativeSizeAxes = Axes.Y;
             Height = 1f;
 
-            Content.AddRange(new Drawable[]
+            AddRangeInternal(new Drawable[]
             {
                 skinnedJoin = new SkinnableDrawable(new RushSkinComponent(RushSkinComponents.DualHitJoin), _ => new DualHitJoinPiece()),
                 airHitContainer = new Container<DrawableDualHitPart> { RelativeSizeAxes = Axes.Both },
@@ -109,7 +109,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                     break;
 
                 case ArmedState.Hit:
-                    ProxyContent();
                     skinnedJoin.Hide();
                     this.FadeOut(animation_time);
                     break;

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         public DrawableDualHitPart Air => airHitContainer.Child;
         public DrawableDualHitPart Ground => groundHitContainer.Child;
 
+        public override bool DisplayResult => false;
+
         public DrawableDualHit()
         : this(null)
         { }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             Size = new Vector2(RushPlayfield.HIT_TARGET_SIZE);
 
-            Content.Add(new SkinnableDrawable(new RushSkinComponent(RushSkinComponents.DualHitPart), _ => new DualHitPartPiece()));
+            AddInternal(new SkinnableDrawable(new RushSkinComponent(RushSkinComponents.DualHitPart), _ => new DualHitPartPiece()));
         }
 
         public new bool UpdateResult(bool userTriggered) => base.UpdateResult(userTriggered);
@@ -40,8 +40,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                     break;
 
                 case ArmedState.Hit:
-                    ProxyContent();
-
                     float travelY = 400f * (HitObject.Lane == LanedHitLane.Air ? -1 : 1);
 
                     this.MoveToY(travelY, animation_time, Easing.Out);

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
@@ -16,7 +16,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public DrawableDualHitPart()
             : this(null)
-        { }
+        {
+        }
 
         public DrawableDualHitPart(DualHitPart hitObject)
             : base(hitObject)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
@@ -2,9 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -13,6 +13,10 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
     public class DrawableDualHitPart : DrawableLanedHit<DualHitPart>
     {
         public override bool DisplayExplosion => true;
+
+        public DrawableDualHitPart()
+            : this(null)
+        { }
 
         public DrawableDualHitPart(DualHitPart hitObject)
             : base(hitObject)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             Size = new Vector2(RushPlayfield.HIT_TARGET_SIZE * 2f);
 
-            Content.Add(new ActionBeatSyncedContainer
+            AddInternal(new ActionBeatSyncedContainer
             {
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
@@ -23,7 +23,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public DrawableHeart()
             : this(null)
-        { }
+        {
+        }
 
         public DrawableHeart(Heart hitObject)
             : base(hitObject)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
@@ -44,8 +44,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             });
         }
 
-        public override Drawable CreateHitExplosion() => new HeartHitExplosion(this);
-
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (AllJudged)
@@ -72,26 +70,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             // else if we're still able to hit it, check if the player is in the correct lane
             else if (playfield.PlayerSprite.CollidesWith(HitObject))
                 ApplyResult(r => r.Type = r.Judgement.MaxResult);
-        }
-
-        private class HeartHitExplosion : HeartPiece
-        {
-            public HeartHitExplosion(DrawableHeart drawableHeart)
-            {
-                Anchor = drawableHeart.LaneAnchor;
-                Origin = Anchor.Centre;
-                Size = drawableHeart.Size;
-                Scale = new Vector2(0.5f);
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                this.ScaleTo(1.25f, RushPlayfield.HIT_EXPLOSION_DURATION)
-                    .FadeOutFromOne(RushPlayfield.HIT_EXPLOSION_DURATION)
-                    .Expire(true);
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
@@ -21,6 +21,10 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         protected override float LifetimeEndDelay => 0f;
         protected override bool ExpireOnHit => false;
 
+        public DrawableHeart()
+            : this(null)
+        { }
+
         public DrawableHeart(Heart hitObject)
             : base(hitObject)
         {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
@@ -18,13 +18,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
     {
         public virtual Color4 LaneAccentColour => HitObject.Lane == LanedHitLane.Air ? AIR_ACCENT_COLOUR : GROUND_ACCENT_COLOUR;
 
-        public Anchor LaneAnchor =>
-            HitObject.Lane switch
-            {
-                LanedHitLane.Air => Direction.Value == ScrollingDirection.Left ? Anchor.TopLeft : Anchor.TopRight,
-                LanedHitLane.Ground => Direction.Value == ScrollingDirection.Left ? Anchor.BottomLeft : Anchor.BottomRight,
-                _ => Direction.Value == ScrollingDirection.Left ? Anchor.BottomLeft : Anchor.BottomRight
-            };
+        public Anchor LaneAnchor => Direction.Value == ScrollingDirection.Left ? Anchor.CentreLeft : Anchor.CentreRight;
 
         public Anchor LeadingAnchor => Direction.Value == ScrollingDirection.Left ? Anchor.CentreLeft : Anchor.CentreRight;
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
@@ -33,7 +33,9 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         public LanedHitLane Lane { get; set; }
 
         public DrawableLanedHit()
-        : base(null) { }
+            : base(null)
+        {
+        }
 
         public DrawableLanedHit(TLanedHit hitObject)
             : base(hitObject)
@@ -50,10 +52,11 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         protected virtual void AdjustAnchor()
         {
-            if (HitObject is null) return;
+            if (HitObject is null)
+                return;
+
             Anchor = LaneAnchor;
         }
-
 
         protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)
         {
@@ -90,11 +93,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                 return;
 
             ApplyResult(r => r.Type = result);
-        }
-
-        protected override void UpdateStartTimeStateTransforms()
-        {
-            base.UpdateStartTimeStateTransforms();
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
@@ -31,18 +31,31 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public Anchor TrailingAnchor => Direction.Value == ScrollingDirection.Left ? Anchor.CentreRight : Anchor.CentreLeft;
 
-        public LanedHitLane Lane => HitObject.Lane;
+        public LanedHitLane Lane => HitObject?.Lane ?? LanedHitLane.Air;
 
         public DrawableLanedHit(TLanedHit hitObject)
             : base(hitObject)
         {
         }
 
+        protected override void OnApply()
+        {
+            base.OnApply();
+            AdjustAnchor();
+            AccentColour.Value = LaneAccentColour;
+        }
+
+        protected virtual void AdjustAnchor()
+        {
+            if (HitObject is null) return;
+            Anchor = LaneAnchor;
+        }
+
+
         protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)
         {
             base.OnDirectionChanged(e);
-
-            Anchor = LaneAnchor;
+            AdjustAnchor();
         }
 
         public override bool OnPressed(RushAction action)
@@ -85,8 +98,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         protected override void UpdateStartTimeStateTransforms()
         {
             base.UpdateStartTimeStateTransforms();
-
-            AccentColour.Value = LaneAccentColour;
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
@@ -45,23 +45,18 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         protected override void OnApply()
         {
             base.OnApply();
+
             Lane = HitObject.Lane;
-            AdjustAnchor();
-            AccentColour.Value = LaneAccentColour;
-        }
-
-        protected virtual void AdjustAnchor()
-        {
-            if (HitObject is null)
-                return;
-
             Anchor = LaneAnchor;
+            AccentColour.Value = LaneAccentColour;
         }
 
         protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)
         {
             base.OnDirectionChanged(e);
-            AdjustAnchor();
+
+            if (HitObject != null)
+                Anchor = LaneAnchor;
         }
 
         public override bool OnPressed(RushAction action)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
@@ -4,12 +4,9 @@
 using System.Diagnostics;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
@@ -67,15 +64,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         }
 
         public virtual bool LaneMatchesAction(RushAction action) => action.Lane() == HitObject.Lane;
-
-        public override Drawable CreateHitExplosion() => new DefaultHitExplosion(LaneAccentColour)
-        {
-            Anchor = LaneAnchor,
-            Origin = Anchor.Centre,
-            Size = new Vector2(200, 200),
-            Scale = new Vector2(0.9f + RNG.NextSingle() * 0.2f),
-            Rotation = RNG.NextSingle() * 360f,
-        };
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
@@ -25,6 +25,11 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public event Action<DrawableMiniBoss, double> Attacked;
 
+        public DrawableMiniBoss()
+            : this(null)
+        {
+        }
+
         public DrawableMiniBoss(MiniBoss hitObject)
             : base(hitObject)
         {
@@ -56,7 +61,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         protected override void ClearNestedHitObjects()
         {
             base.ClearNestedHitObjects();
-            ticks.Clear();
+            ticks.Clear(false);
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
@@ -147,8 +147,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                     break;
 
                 case ArmedState.Hit:
-                    ProxyContent();
-
                     const float gravity_time = 300;
                     const float gravity_travel_height = 500f;
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBossTick.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBossTick.cs
@@ -10,6 +10,11 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
     {
         public override bool DisplayResult => false;
 
+        public DrawableMiniBossTick()
+            : this(null)
+        {
+        }
+
         public DrawableMiniBossTick(MiniBossTick hitObject)
             : base(hitObject)
         {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
@@ -4,9 +4,9 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -25,7 +25,12 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public override bool DisplayExplosion => true;
 
-        public DrawableMinion(Minion hitObject)
+        public DrawableMinion()
+            : this(null)
+        {
+        }
+
+        public DrawableMinion(Minion hitObject = null)
             : base(hitObject)
         {
             Size = new Vector2(RushPlayfield.HIT_TARGET_SIZE);

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
@@ -41,16 +41,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             });
         }
 
-        public Action<LanedHit> OnHitObjectApplied;
-
-        protected override void OnApply()
-        {
-            base.OnApply();
-
-            // Not clean at all, I hate it
-            OnHitObjectApplied?.Invoke(HitObject);
-        }
-
         protected override void Update()
         {
             base.Update();

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
@@ -41,6 +41,16 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             });
         }
 
+        public Action<LanedHit> OnHitObjectApplied;
+
+        protected override void OnApply()
+        {
+            base.OnApply();
+
+            // Not clean at all, I hate it
+            OnHitObjectApplied?.Invoke(HitObject);
+        }
+
         protected override void Update()
         {
             base.Update();

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             Size = new Vector2(RushPlayfield.HIT_TARGET_SIZE);
 
-            Content.Add(minionPiece = new SkinnableDrawable(new RushSkinComponent(Component), _ => new MinionPiece())
+            AddInternal(minionPiece = new SkinnableDrawable(new RushSkinComponent(Component), _ => new MinionPiece())
             {
                 RelativeSizeAxes = Axes.Both
             });

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
@@ -5,19 +5,16 @@ using System;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Bindings;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Judgements;
 using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.UI.Scrolling;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
@@ -135,15 +132,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             }
         }
 
-        public virtual Drawable CreateHitExplosion() => new DefaultHitExplosion(Color4.Yellow.Darken(0.5f))
-        {
-            Anchor = Anchor,
-            Origin = Anchor.Centre,
-            Size = new Vector2(200, 200),
-            Scale = new Vector2(0.9f + RNG.NextSingle() * 0.2f),
-            Rotation = RNG.NextSingle() * 360f,
-        };
-
         protected override JudgementResult CreateResult(Judgement judgement) => new RushJudgementResult(HitObject, (RushJudgement)judgement);
 
         protected new void ApplyResult(Action<JudgementResult> application)
@@ -191,7 +179,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             public override bool RemoveWhenNotAlive => false;
         }
-
         #endregion
     }
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
@@ -181,6 +181,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             public override bool RemoveWhenNotAlive => false;
         }
+
         #endregion
     }
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
         }
 
-        protected override void UpdateStartTimeStateTransforms() => UnproxyContent();
+        //protected override void UpdateStartTimeStateTransforms() => UnproxyContent();
 
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             {
                 case ArmedState.Miss:
                     AccentColour.Value = Color4.Gray;
-                    ProxyContent();
+                    //ProxyContent();
 
                     if (!ExpireOnMiss)
                         LifetimeEnd = HitObject.GetEndTime() + LifetimeEndDelay;
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                     break;
 
                 case ArmedState.Hit:
-                    ProxyContent();
+                    //ProxyContent();
 
                     if (!ExpireOnHit)
                         LifetimeEnd = HitObject.GetEndTime() + LifetimeEndDelay;

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
@@ -198,12 +198,11 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
     public abstract class DrawableRushHitObject<TObject> : DrawableRushHitObject
         where TObject : RushHitObject
     {
-        public new readonly TObject HitObject;
+        public new TObject HitObject => (TObject)base.HitObject;
 
         protected DrawableRushHitObject(TObject hitObject)
             : base(hitObject)
         {
-            HitObject = hitObject;
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushJudgement.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushJudgement.cs
@@ -14,7 +14,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public DrawableRushJudgement()
             : this(null, null)
-        { }
+        {
+        }
 
         public DrawableRushJudgement(JudgementResult result, DrawableRushHitObject judgedObject)
             : base(result, judgedObject)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushJudgement.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushJudgement.cs
@@ -24,14 +24,19 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             Origin = Anchor.Centre;
         }
 
+        public Vector2 StartPosition = Vector2.Zero;
+        public Vector2 StartScale = Vector2.One;
+
         protected override void ApplyHitAnimations() =>
-            this.ScaleTo(1f, judgement_time)
+            this.MoveTo(StartPosition).ScaleTo(StartScale)
+                .ScaleTo(1f, judgement_time)
                 .Then()
                 .MoveToOffset(new Vector2(-judgement_movement, 0f), judgement_time, Easing.In)
                 .Expire();
 
         protected override void ApplyMissAnimations() =>
-            this.ScaleTo(1f, judgement_time)
+            this.MoveTo(StartPosition).ScaleTo(StartScale)
+                .ScaleTo(1f, judgement_time)
                 .Then()
                 .MoveToOffset(new Vector2(-judgement_movement, 0f), judgement_time, Easing.In)
                 .Expire();

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushJudgement.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushJudgement.cs
@@ -3,8 +3,6 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Rush.UI;
 using osuTK;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushJudgement.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushJudgement.cs
@@ -3,6 +3,8 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Rush.UI;
 using osuTK;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
@@ -12,9 +14,14 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         private const float judgement_time = 250f;
         private const float judgement_movement = 300;
 
+        public DrawableRushJudgement()
+            : this(null, null)
+        { }
+
         public DrawableRushJudgement(JudgementResult result, DrawableRushHitObject judgedObject)
             : base(result, judgedObject)
         {
+            Origin = Anchor.Centre;
         }
 
         protected override void ApplyHitAnimations() =>

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
@@ -29,7 +29,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public DrawableSawblade()
             : this(null)
-        { }
+        {
+        }
 
         public DrawableSawblade(Sawblade hitObject)
             : base(hitObject)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
@@ -24,6 +24,13 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         protected override bool ExpireOnHit => false;
         protected override bool ExpireOnMiss => false;
 
+        private readonly Container sawbladeContainer;
+        private readonly Drawable sawblade;
+
+        public DrawableSawblade()
+            : this(null)
+        { }
+
         public DrawableSawblade(Sawblade hitObject)
             : base(hitObject)
         {
@@ -31,22 +38,28 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
             Content.AddRange(new[]
             {
-                new Container
+                sawbladeContainer = new Container
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
                     Size = new Vector2(0.8f),
-                    Masking = hitObject.Lane == LanedHitLane.Ground,
-                    Child = new SkinnableDrawable(new RushSkinComponent(RushSkinComponents.Sawblade), _ => new SawbladePiece())
+                    Child = sawblade = new SkinnableDrawable(new RushSkinComponent(RushSkinComponents.Sawblade), _ => new SawbladePiece())
                     {
                         Origin = Anchor.Centre,
-                        Anchor = hitObject.Lane == LanedHitLane.Ground ? Anchor.BottomCentre : Anchor.TopCentre,
                         RelativeSizeAxes = Axes.Both,
                         Size = new Vector2(0.8f)
                     }
                 }
             });
+        }
+
+        protected override void OnApply()
+        {
+            base.OnApply();
+
+            sawbladeContainer.Masking = HitObject.Lane == LanedHitLane.Ground;
+            sawblade.Anchor = HitObject.Lane == LanedHitLane.Ground ? Anchor.BottomCentre : Anchor.TopCentre;
         }
 
         // Sawblade doesn't handle user presses at all.

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             Size = new Vector2(RushPlayfield.HIT_TARGET_SIZE * 2f);
 
-            Content.AddRange(new[]
+            AddRangeInternal(new[]
             {
                 sawbladeContainer = new Container
                 {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             Height = NOTE_SHEET_SIZE;
 
-            Content.AddRange(new[]
+            AddRangeInternal(new[]
             {
                 bodyContainer = new Container<SkinnableDrawable>
                 {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
@@ -11,7 +11,6 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Rush.UI;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
@@ -7,10 +7,10 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
@@ -56,6 +56,9 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public override bool DisplayResult => false;
 
+        public DrawableStarSheet()
+            : this(null) { }
+
         public DrawableStarSheet(StarSheet hitObject)
             : base(hitObject)
         {
@@ -97,24 +100,24 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         protected override void ClearNestedHitObjects()
         {
             base.ClearNestedHitObjects();
-            headContainer.Clear();
-            tailContainer.Clear();
+            headContainer.Clear(false);
+            tailContainer.Clear(false);
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
-                case StarSheetHead _:
-                    return new DrawableStarSheetHead(this)
+                case StarSheetHead head:
+                    return new DrawableStarSheetHead(head)
                     {
                         Anchor = LeadingAnchor,
                         Origin = Anchor.Centre,
                         AccentColour = { BindTarget = AccentColour }
                     };
 
-                case StarSheetTail _:
-                    return new DrawableStarSheetTail(this)
+                case StarSheetTail tail:
+                    return new DrawableStarSheetTail(tail)
                     {
                         Anchor = TrailingAnchor,
                         Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
@@ -189,16 +189,16 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public override void OnReleased(RushAction action)
         {
+            // Note sheet not held yet (i.e. not our time yet) or already broken / finished.
+            if (Judged || !Head.IsHit)
+                return;
+
             if (!LaneMatchesAction(action))
                 return;
 
             // Check if there was also another action holding the same star sheet,
             // and use it in replace to this released one if so. (support for switching keys during hold)
             if (ActionInputManager.PressedActions.Count(LaneMatchesAction) > 1)
-                return;
-
-            // Note sheet not held yet (i.e. not our time yet) or already broken / finished.
-            if (!Head.IsHit || Judged)
                 return;
 
             UpdateResult(true);

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
@@ -47,12 +47,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             }
         }
 
-        [Resolved]
-        private IScrollingInfo scrollingInfo { get; set; }
-
-        [Resolved]
-        private RushPlayfield playfield { get; set; }
-
         public override bool DisplayResult => false;
 
         public DrawableStarSheet()

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
@@ -56,7 +56,9 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         public override bool DisplayResult => false;
 
         public DrawableStarSheet()
-            : this(null) { }
+            : this(null)
+        {
+        }
 
         public DrawableStarSheet(StarSheet hitObject)
             : base(hitObject)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
-using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 using osuTK;

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
@@ -56,8 +56,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             AccentColour.UnbindFrom(StarSheet.AccentColour);
         }
 
-        public override Drawable CreateHitExplosion() => new StarSheetHitExplosion(this);
-
         protected override void UpdateStartTimeStateTransforms()
         {
             Scale = Vector2.One;
@@ -82,51 +80,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public override void OnReleased(RushAction action)
         {
-        }
-
-        private class StarSheetHitExplosion : CompositeDrawable
-        {
-            private readonly StarSheetCapStarPiece explosionStar;
-            private readonly Circle flashCircle;
-
-            public StarSheetHitExplosion(DrawableStarSheetCap<TObject> drawableStarSheet)
-            {
-                Anchor = drawableStarSheet.LaneAnchor;
-                Origin = Anchor.Centre;
-                Size = drawableStarSheet.Size;
-
-                InternalChildren = new Drawable[]
-                {
-                    explosionStar = new StarSheetCapStarPiece(),
-                    flashCircle = new Circle
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Alpha = 0.4f,
-                        RelativeSizeAxes = Axes.Both,
-                        Scale = new Vector2(0.5f),
-                        Colour = drawableStarSheet.LaneAccentColour.Lighten(0.5f)
-                    }
-                };
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                explosionStar.ScaleTo(2f, RushPlayfield.HIT_EXPLOSION_DURATION)
-                             .FadeOutFromOne(RushPlayfield.HIT_EXPLOSION_DURATION)
-                             .Expire(true);
-
-                flashCircle.ScaleTo(4f, RushPlayfield.HIT_EXPLOSION_DURATION / 2)
-                           .Then()
-                           .ScaleTo(0.5f, RushPlayfield.HIT_EXPLOSION_DURATION / 2)
-                           .FadeOut(RushPlayfield.HIT_EXPLOSION_DURATION / 2)
-                           .Expire(true);
-
-                // TODO: very low priority for now, but this shouldn't stay as-is in every similar composite.
-                this.Delay(InternalChildren.Max(d => d.LatestTransformEndTime)).Expire(true);
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         protected DrawableStarSheet StarSheet => (DrawableStarSheet)ParentHitObject;
 
+        protected abstract Anchor CapAnchor { get; }
+
         public override bool DisplayExplosion => true;
 
         protected DrawableStarSheetCap(TObject hitObject)
@@ -37,6 +39,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         protected override void OnApply()
         {
             base.OnApply();
+
+            Anchor = CapAnchor;
             AccentColour.BindTo(StarSheet.AccentColour);
         }
 
@@ -62,9 +66,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public bool TriggerResult() => UpdateResult(true);
 
-        protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)
-        {
-        }
+        protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e) => Anchor = CapAnchor;
 
         public override bool OnPressed(RushAction action) => false; // Handled by the star sheet object itself.
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
@@ -1,13 +1,9 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Rush.UI;

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
@@ -26,12 +26,12 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             Size = new Vector2(DrawableStarSheet.NOTE_SHEET_SIZE * 1.1f);
             Origin = Anchor.Centre;
 
-            Content.Child = new SkinnableDrawable(new RushSkinComponent(Component), _ => new StarSheetCapStarPiece())
+            AddInternal(new SkinnableDrawable(new RushSkinComponent(Component), _ => new StarSheetCapStarPiece())
             {
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
-            };
+            });
         }
 
         protected override void OnApply()

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
@@ -24,17 +24,16 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         private readonly Drawable capPiece;
 
-        protected readonly DrawableStarSheet StarSheet;
+        protected DrawableStarSheet StarSheet => (DrawableStarSheet)ParentHitObject;
 
         [Resolved]
         private RushPlayfield playfield { get; set; }
 
         public override bool DisplayExplosion => true;
 
-        protected DrawableStarSheetCap(DrawableStarSheet starSheet, TObject hitObject)
+        protected DrawableStarSheetCap(TObject hitObject)
             : base(hitObject)
         {
-            StarSheet = starSheet;
             Size = new Vector2(DrawableStarSheet.NOTE_SHEET_SIZE * 1.1f);
             Origin = Anchor.Centre;
 
@@ -44,6 +43,17 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                 Anchor = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
             };
+        }
+
+        protected override void OnApply()
+        {
+            base.OnApply();
+            AccentColour.BindTo(StarSheet.AccentColour);
+        }
+        protected override void OnFree()
+        {
+            base.OnFree();
+            AccentColour.UnbindFrom(StarSheet.AccentColour);
         }
 
         public override Drawable CreateHitExplosion() => new StarSheetHitExplosion(this);

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetCap.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             base.OnApply();
             AccentColour.BindTo(StarSheet.AccentColour);
         }
+
         protected override void OnFree()
         {
             base.OnFree();

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
@@ -11,7 +11,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         public DrawableStarSheetHead()
             : this(null)
-        { }
+        {
+        }
 
         public DrawableStarSheetHead(StarSheetHead starSheetHead)
             : base(starSheetHead)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
@@ -11,8 +11,12 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
     {
         protected override RushSkinComponents Component => RushSkinComponents.StarSheetHead;
 
-        public DrawableStarSheetHead(DrawableStarSheet starSheet)
-            : base(starSheet, starSheet.HitObject.Head)
+        public DrawableStarSheetHead()
+            : this(null)
+        { }
+
+        public DrawableStarSheetHead(StarSheetHead starSheetHead)
+            : base(starSheetHead)
         {
         }
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
@@ -36,7 +36,9 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         protected override void AdjustAnchor()
         {
-            if (HitObject is null) return;
+            if (HitObject is null)
+                return;
+
             Anchor = LeadingAnchor;
         }
     }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
@@ -32,6 +32,10 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             }
         }
 
-        protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e) => Anchor = LeadingAnchor;
+        protected override void AdjustAnchor()
+        {
+            if (HitObject is null) return;
+            Anchor = LeadingAnchor;
+        }
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
@@ -8,6 +9,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
     public class DrawableStarSheetHead : DrawableStarSheetCap<StarSheetHead>
     {
         protected override RushSkinComponents Component => RushSkinComponents.StarSheetHead;
+
+        protected override Anchor CapAnchor => LeadingAnchor;
 
         public DrawableStarSheetHead()
             : this(null)
@@ -33,14 +36,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             {
                 ApplyResult(r => r.Type = r.Judgement.MinResult);
             }
-        }
-
-        protected override void AdjustAnchor()
-        {
-            if (HitObject is null)
-                return;
-
-            Anchor = LeadingAnchor;
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
@@ -46,6 +46,10 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         }
 
         // FIXME: should logically be TrailingAnchor, not sure why it renders incorrectly
-        protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e) => Anchor = LeadingAnchor;
+        protected override void AdjustAnchor()
+        {
+            if (HitObject is null) return;
+            Anchor = LeadingAnchor;
+        }
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
@@ -1,15 +1,17 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
 {
     public class DrawableStarSheetTail : DrawableStarSheetCap<StarSheetTail>
     {
-        internal const double RELEASE_WINDOW_LENIENCE = 3;
-
         protected override RushSkinComponents Component => RushSkinComponents.StarSheetTail;
+
+        // FIXME: should logically be TrailingAnchor, not sure why it renders incorrectly
+        protected override Anchor CapAnchor => LeadingAnchor;
 
         public DrawableStarSheetTail()
             : this(null)
@@ -46,15 +48,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
             // ...and an automatic perfect if they release within any "hit" judged period
             ApplyResult(r => r.Type = r.Judgement.MaxResult);
-        }
-
-        // FIXME: should logically be TrailingAnchor, not sure why it renders incorrectly
-        protected override void AdjustAnchor()
-        {
-            if (HitObject is null)
-                return;
-
-            Anchor = LeadingAnchor;
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
@@ -13,8 +13,13 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         protected override RushSkinComponents Component => RushSkinComponents.StarSheetTail;
 
-        public DrawableStarSheetTail(DrawableStarSheet starSheet)
-            : base(starSheet, starSheet.HitObject.Tail)
+        public DrawableStarSheetTail()
+            : this(null)
+        {
+        }
+
+        public DrawableStarSheetTail(StarSheetTail starSheetTail)
+            : base(starSheetTail)
         {
         }
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
@@ -51,7 +51,9 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         // FIXME: should logically be TrailingAnchor, not sure why it renders incorrectly
         protected override void AdjustAnchor()
         {
-            if (HitObject is null) return;
+            if (HitObject is null)
+                return;
+
             Anchor = LeadingAnchor;
         }
     }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/IDrawableLanedHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/IDrawableLanedHit.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osuTK.Graphics;
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/IDrawableLanedHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/IDrawableLanedHit.cs
@@ -8,9 +8,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 {
     public interface IDrawableLanedHit
     {
-        Color4 LaneAccentColour { get; }
-        Anchor LaneAnchor { get; }
-
         LanedHitLane Lane { get; set; }
+        Anchor LaneAnchor { get; }
+        Color4 LaneAccentColour { get; }
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/HeartPiece.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/HeartPiece.cs
@@ -3,13 +3,14 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables.Pieces
 {
-    public class HeartPiece : CompositeDrawable
+    public class HeartPiece : PoolableDrawable
     {
         public HeartPiece()
         {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/HeartPiece.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/HeartPiece.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Sprites;
 using osuTK;

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/MinionPiece.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/MinionPiece.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
-using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables.Pieces
 {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/MinionPiece.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/MinionPiece.cs
@@ -29,16 +29,24 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables.Pieces
             };
         }
 
+        [Resolved]
+        private TextureStore textures { get; set; }
+
         [BackgroundDependencyLoader(true)]
-        private void load(TextureStore store, [CanBeNull] DrawableHitObject drawableHitObject)
+        private void load([CanBeNull] DrawableHitObject drawableHitObject)
         {
-            // This poses a problem for pooling, as this code is only executed once, before any HitObject is assigned to the pooled drawable
+            if (drawableHitObject is DrawableMinion drawableMinion)
+                drawableMinion.OnHitObjectApplied += ApplyVisuals;
+        }
+
+        public void ApplyVisuals(LanedHit HitObject)
+        {
+            animation.ClearFrames();
 
             var laneStr = "air";
-            if (drawableHitObject is IDrawableLanedHit drawableLanedHit)
-                laneStr = drawableLanedHit.Lane == LanedHitLane.Air ? "air" : "ground";
+            laneStr = HitObject.Lane == LanedHitLane.Air ? "air" : "ground";
 
-            animation.AddFrames(new[] { store.Get($"Minion/pippidon_{laneStr}_0"), store.Get($"Minion/pippidon_{laneStr}_1") });
+            animation.AddFrames(new[] { textures.Get($"Minion/pippidon_{laneStr}_0"), textures.Get($"Minion/pippidon_{laneStr}_1") });
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/MinionPiece.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/MinionPiece.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables.Pieces
         [BackgroundDependencyLoader(true)]
         private void load(TextureStore store, [CanBeNull] DrawableHitObject drawableHitObject)
         {
+            // This poses a problem for pooling, as this code is only executed once, before any HitObject is assigned to the pooled drawable
+
             var laneStr = "air";
             if (drawableHitObject is IDrawableLanedHit drawableLanedHit)
                 laneStr = drawableLanedHit.Lane == LanedHitLane.Air ? "air" : "ground";

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -94,7 +94,6 @@ namespace osu.Game.Rulesets.Rush
 
         public override Drawable CreateIcon() => new RushIcon();
 
-
         protected override IEnumerable<HitResult> GetValidHitResults()
         {
             return new[]
@@ -103,7 +102,6 @@ namespace osu.Game.Rulesets.Rush
                 HitResult.Great,
             };
         }
-
 
         public class RushIcon : CompositeDrawable
         {

--- a/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
@@ -69,10 +70,24 @@ namespace osu.Game.Rulesets.Rush.UI
 
         public void Apply(DrawableHitObject HitObject)
         {
-            IDrawableLanedHit laned = HitObject as IDrawableLanedHit;
-            colouredExplosion.Colour = laned.LaneAccentColour;
-            Anchor = laned.LaneAnchor;
-            Rotation = RNG.NextSingle() * 360f;
+            if (HitObject is DrawableMiniBoss miniBoss)
+            {
+                Alpha = 0;
+                Depth = 0;
+                Origin = Anchor.Centre;
+                Anchor = miniBoss.Anchor;
+                Size = new Vector2(200, 200);
+                Scale = new Vector2(0.9f + RNG.NextSingle() * 0.2f) * 1.5f;
+                Rotation = RNG.NextSingle() * 360f;
+                colouredExplosion.Colour = Color4.Yellow.Darken(0.5f);
+            }
+            else
+            {
+                IDrawableLanedHit laned = HitObject as IDrawableLanedHit;
+                colouredExplosion.Colour = laned.LaneAccentColour;
+                Anchor = laned.LaneAnchor;
+                Rotation = RNG.NextSingle() * 360f;
+            }
         }
 
         [BackgroundDependencyLoader]
@@ -94,7 +109,7 @@ namespace osu.Game.Rulesets.Rush.UI
         /// </summary>
         protected virtual void ApplyExplosionTransforms()
         {
-            this.ScaleTo(0.5f, RushPlayfield.HIT_EXPLOSION_DURATION)
+            this.ScaleTo(Scale * 0.5f, RushPlayfield.HIT_EXPLOSION_DURATION)
                 .FadeOutFromOne(RushPlayfield.HIT_EXPLOSION_DURATION)
                 .Expire(true);
         }

--- a/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
@@ -26,6 +26,8 @@ namespace osu.Game.Rulesets.Rush.UI
         private readonly Sprite colouredExplosion;
         private readonly Sprite whiteExplosion;
 
+        private readonly Sparks sparks;
+
         public override bool RemoveWhenNotAlive => true;
         public override bool RemoveCompletedTransforms => false;
 
@@ -56,7 +58,7 @@ namespace osu.Game.Rulesets.Rush.UI
                     Origin = Anchor.Centre,
                     Scale = new Vector2(0.75f)
                 },
-                new Sparks(sparkCount)
+                sparks = new Sparks(sparkCount)
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -112,10 +114,14 @@ namespace osu.Game.Rulesets.Rush.UI
             this.ScaleTo(Scale * 0.5f, RushPlayfield.HIT_EXPLOSION_DURATION)
                 .FadeOutFromOne(RushPlayfield.HIT_EXPLOSION_DURATION)
                 .Expire(true);
+
+            sparks.Animate();
         }
 
         protected class Sparks : CompositeDrawable
         {
+            public override bool RemoveCompletedTransforms => false;
+
             private const double average_duration = 1500f;
 
             private readonly Random random = new Random();
@@ -144,16 +150,14 @@ namespace osu.Game.Rulesets.Rush.UI
                 InternalChildren = triangles;
             }
 
-            protected override void LoadComplete()
+            public void Animate()
             {
-                base.LoadComplete();
-
                 foreach (var triangle in triangles)
                 {
                     var scale = 0.8f + random.NextDouble() * 0.2f;
                     var duration = average_duration * (0.8f + random.NextDouble() * 0.4f);
                     var radians = MathUtils.DegreesToRadians(triangle.Rotation + 90);
-                    var distance = DrawWidth * (0.8f + random.NextDouble() * 0.2f);
+                    var distance = 400 * (0.8f + random.NextDouble() * 0.2f);
                     var target = new Vector2(MathF.Cos(radians), MathF.Sin(radians)) * (float)distance;
                     triangle.Scale = new Vector2((float)scale);
                     triangle.MoveTo(target, duration, Easing.OutExpo);

--- a/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
@@ -12,9 +12,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Rush.Objects;
 using osu.Game.Rulesets.Rush.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
@@ -101,8 +99,8 @@ namespace osu.Game.Rulesets.Rush.UI
 
         protected override void PrepareForUse()
         {
-            ApplyTransformsAt(double.MinValue);
-            ClearTransforms();
+            ApplyTransformsAt(double.MinValue, true);
+            ClearTransforms(true);
             ApplyExplosionTransforms();
         }
 
@@ -157,7 +155,7 @@ namespace osu.Game.Rulesets.Rush.UI
                     var scale = 0.8f + random.NextDouble() * 0.2f;
                     var duration = average_duration * (0.8f + random.NextDouble() * 0.4f);
                     var radians = MathUtils.DegreesToRadians(triangle.Rotation + 90);
-                    var distance = 400 * (0.8f + random.NextDouble() * 0.2f);
+                    var distance = DrawWidth * (0.8f + random.NextDouble() * 0.2f);
                     var target = new Vector2(MathF.Cos(radians), MathF.Sin(radians)) * (float)distance;
                     triangle.Scale = new Vector2((float)scale);
                     triangle.MoveTo(target, duration, Easing.OutExpo);

--- a/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
@@ -6,26 +6,39 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Rush.Objects;
+using osu.Game.Rulesets.Rush.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Rush.UI
 {
-    public class DefaultHitExplosion : CompositeDrawable
+    public class DefaultHitExplosion : PoolableDrawable
     {
         private readonly Sprite colouredExplosion;
         private readonly Sprite whiteExplosion;
 
         public override bool RemoveWhenNotAlive => true;
+        public override bool RemoveCompletedTransforms => false;
+
+        public DefaultHitExplosion()
+            : this(Color4.White)
+        {
+        }
 
         public DefaultHitExplosion(Color4 explosionColour, int sparkCount = 10, Color4? sparkColour = null)
         {
-            Origin = Anchor.Centre;
             Depth = 1f;
+            Origin = Anchor.Centre;
+            Size = new Vector2(200, 200);
+            Scale = new Vector2(0.9f + RNG.NextSingle() * 0.2f);
 
             InternalChildren = new Drawable[]
             {
@@ -54,6 +67,14 @@ namespace osu.Game.Rulesets.Rush.UI
             };
         }
 
+        public void Apply(DrawableHitObject HitObject)
+        {
+            IDrawableLanedHit laned = HitObject as IDrawableLanedHit;
+            colouredExplosion.Colour = laned.LaneAccentColour;
+            Anchor = laned.LaneAnchor;
+            Rotation = RNG.NextSingle() * 360f;
+        }
+
         [BackgroundDependencyLoader]
         private void load(TextureStore store)
         {
@@ -61,10 +82,10 @@ namespace osu.Game.Rulesets.Rush.UI
             whiteExplosion.Texture = store.Get("Effects/explosion");
         }
 
-        protected override void LoadComplete()
+        protected override void PrepareForUse()
         {
-            base.LoadComplete();
-
+            ApplyTransformsAt(double.MinValue);
+            ClearTransforms();
             ApplyExplosionTransforms();
         }
 

--- a/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/DefaultHitExplosion.cs
@@ -68,9 +68,9 @@ namespace osu.Game.Rulesets.Rush.UI
             };
         }
 
-        public void Apply(DrawableHitObject HitObject)
+        public void Apply(DrawableHitObject hitObject)
         {
-            if (HitObject is DrawableMiniBoss miniBoss)
+            if (hitObject is DrawableMiniBoss miniBoss)
             {
                 Alpha = 0;
                 Depth = 0;
@@ -81,9 +81,8 @@ namespace osu.Game.Rulesets.Rush.UI
                 Rotation = RNG.NextSingle() * 360f;
                 colouredExplosion.Colour = Color4.Yellow.Darken(0.5f);
             }
-            else
+            else if (hitObject is IDrawableLanedHit laned)
             {
-                IDrawableLanedHit laned = HitObject as IDrawableLanedHit;
                 colouredExplosion.Colour = laned.LaneAccentColour;
                 Anchor = laned.LaneAnchor;
                 Rotation = RNG.NextSingle() * 360f;

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Rush.UI
             switch (h)
             {
                 case Minion minion:
-                    return new DrawableMinion(minion);
+                    return null;
 
                 case MiniBoss miniBoss:
                     return new DrawableMiniBoss(miniBoss);

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -12,7 +12,6 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects;
-using osu.Game.Rulesets.Rush.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Replays;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Rush.UI
                     return null;
 
                 case MiniBoss miniBoss:
-                    return new DrawableMiniBoss(miniBoss);
+                    return null;
 
                 case StarSheet starSheet:
                     return new DrawableStarSheet(starSheet);

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Rush.UI
                     return null;
 
                 case Sawblade sawblade:
-                    return new DrawableSawblade(sawblade);
+                    return null;
 
                 case Heart heart:
                     return new DrawableHeart(heart);

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Rush.UI
                     return null;
 
                 case DualHit dualHit:
-                    return new DrawableDualHit(dualHit);
+                    return null;
 
                 case Sawblade sawblade:
                     return new DrawableSawblade(sawblade);

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Rush.UI
                     return null;
 
                 case StarSheet starSheet:
-                    return new DrawableStarSheet(starSheet);
+                    return null;
 
                 case DualHit dualHit:
                     return new DrawableDualHit(dualHit);

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -41,31 +41,7 @@ namespace osu.Game.Rulesets.Rush.UI
 
         public new RushPlayfield Playfield => (RushPlayfield)base.Playfield;
 
-        public override DrawableHitObject<RushHitObject> CreateDrawableRepresentation(RushHitObject h)
-        {
-            switch (h)
-            {
-                case Minion minion:
-                    return null;
-
-                case MiniBoss miniBoss:
-                    return null;
-
-                case StarSheet starSheet:
-                    return null;
-
-                case DualHit dualHit:
-                    return null;
-
-                case Sawblade sawblade:
-                    return null;
-
-                case Heart heart:
-                    return new DrawableHeart(heart);
-            }
-
-            return null;
-        }
+        public override DrawableHitObject<RushHitObject> CreateDrawableRepresentation(RushHitObject h) => null;
 
         protected override PassThroughInputManager CreateInputManager() => new RushInputManager(Ruleset?.RulesetInfo);
     }

--- a/osu.Game.Rulesets.Rush/UI/HealthText.cs
+++ b/osu.Game.Rulesets.Rush/UI/HealthText.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Rush.Objects.Drawables;
+using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Rush.UI
+{
+    public class HealthText : PoolableDrawable
+    {
+        private readonly SpriteText text;
+
+        public override bool RemoveCompletedTransforms => false;
+
+        public HealthText()
+        {
+            Origin = Anchor.Centre;
+            RelativePositionAxes = Axes.Both;
+            Position = new Vector2(0.75f, 0.5f);
+
+            InternalChildren = new Drawable[]
+            {
+                text = new SpriteText
+                {
+                    Font = FontUsage.Default.With(size: 40),
+                    Scale = new Vector2(1.2f),
+                }
+            };
+        }
+
+        public void Apply(double pointDifference)
+        {
+            text.Colour = pointDifference > 0 ? Color4.Green : Color4.Red;
+            text.Text = $"{pointDifference:+0;-0}";
+        }
+
+        protected override void PrepareForUse()
+        {
+            base.PrepareForUse();
+
+            const float judgement_time = 250f;
+
+            ApplyTransformsAt(double.MinValue);
+            ClearTransforms();
+
+            this.ScaleTo(1f, judgement_time)
+                .Then()
+                .FadeOutFromOne(judgement_time)
+                .MoveToOffset(new Vector2(0f, -20f), judgement_time)
+                .Expire(true);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/UI/HealthText.cs
+++ b/osu.Game.Rulesets.Rush/UI/HealthText.cs
@@ -1,13 +1,9 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Rulesets.Rush.Objects.Drawables;
-using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
 using osuTK;
 using osuTK.Graphics;
 

--- a/osu.Game.Rulesets.Rush/UI/HeartHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/HeartHitExplosion.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Rush.Objects.Drawables;
+using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
+using osuTK;
+
+namespace osu.Game.Rulesets.Rush.UI
+{
+    public class HeartHitExplosion : HeartPiece
+    {
+        public override bool RemoveCompletedTransforms => false;
+        public HeartHitExplosion()
+        {
+            Origin = Anchor.Centre;
+            Scale = new Vector2(0.5f);
+        }
+
+        protected override void PrepareForUse()
+        {
+            ApplyTransformsAt(double.MinValue);
+            ClearTransforms();
+
+            this.ScaleTo(1.25f, RushPlayfield.HIT_EXPLOSION_DURATION)
+                .FadeOutFromOne(RushPlayfield.HIT_EXPLOSION_DURATION)
+                .Expire(true);
+        }
+
+        public void Apply(DrawableHeart drawableHeart)
+        {
+            Anchor = drawableHeart.LaneAnchor;
+            Size = drawableHeart.Size;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/UI/HeartHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/HeartHitExplosion.cs
@@ -11,6 +11,7 @@ namespace osu.Game.Rulesets.Rush.UI
     public class HeartHitExplosion : HeartPiece
     {
         public override bool RemoveCompletedTransforms => false;
+
         public HeartHitExplosion()
         {
             Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Rush/UI/LanePlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/LanePlayfield.cs
@@ -87,6 +87,7 @@ namespace osu.Game.Rulesets.Rush.UI
         private class DrawableLanedObjectPool<T> : DrawablePool<T> where T : PoolableDrawable, IDrawableLanedHit, new()
         {
             private readonly LanedHitLane lane;
+
             public DrawableLanedObjectPool(LanedHitLane lane, int initialSize, int? maximumSize)
                 : base(initialSize, maximumSize)
             {

--- a/osu.Game.Rulesets.Rush/UI/LanePlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/LanePlayfield.cs
@@ -82,6 +82,8 @@ namespace osu.Game.Rulesets.Rush.UI
         public void AddExplosion(Drawable drawable) => effectsContainer.Add(drawable);
         public void AddJudgement(DrawableRushJudgement judgement) => judgementContainer.Add(judgement);
 
+        // This pool pre-initializes created DrawableLanedObjects with a predefined lane value
+        // The lane value needs to be set beforehand so that the pieces (Minion, etc) can load using the correct information
         private class DrawableLanedObjectPool<T> : DrawablePool<T> where T : PoolableDrawable, IDrawableLanedHit, new()
         {
             private readonly LanedHitLane lane;

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -56,8 +56,8 @@ namespace osu.Game.Rulesets.Rush.UI
 
         private DrawablePool<DrawableRushJudgement> judgementPool;
         private DrawablePool<DefaultHitExplosion> explosionPool;
-        private DrawablePool<HeartHitExplosion> heartsplosionPool;
         private DrawablePool<StarSheetHitExplosion> sheetsplosionPool;
+        private DrawablePool<HeartHitExplosion> heartsplosionPool;
         private DrawablePool<HealthText> healthTextPool;
 
         [Cached]
@@ -183,9 +183,9 @@ namespace osu.Game.Rulesets.Rush.UI
             AddRangeInternal(new Drawable[]
             {
                 judgementPool = new DrawablePool<DrawableRushJudgement>(5),
-                explosionPool = new DrawablePool<DefaultHitExplosion>(5),
-                heartsplosionPool = new DrawablePool<HeartHitExplosion>(5),
-                sheetsplosionPool = new DrawablePool<StarSheetHitExplosion>(5),
+                explosionPool = new DrawablePool<DefaultHitExplosion>(15),
+                sheetsplosionPool = new DrawablePool<StarSheetHitExplosion>(10),
+                heartsplosionPool = new DrawablePool<HeartHitExplosion>(2),
                 healthTextPool = new DrawablePool<HealthText>(2),
             });
         }

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -210,6 +210,8 @@ namespace osu.Game.Rulesets.Rush.UI
             RegisterPool<StarSheet, DrawableStarSheet>(8);
             RegisterPool<StarSheetHead, DrawableStarSheetHead>(8);
             RegisterPool<StarSheetTail, DrawableStarSheetTail>(8);
+            RegisterPool<DualHit, DrawableDualHit>(8);
+            RegisterPool<DualHitPart, DrawableDualHitPart>(16);
         }
         protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -180,7 +180,8 @@ namespace osu.Game.Rulesets.Rush.UI
             RegisterPool<DualHit, DrawableDualHit>(8);
             RegisterPool<DualHitPart, DrawableDualHitPart>(16);
 
-            AddRangeInternal(new Drawable[]{
+            AddRangeInternal(new Drawable[]
+            {
                 judgementPool = new DrawablePool<DrawableRushJudgement>(5),
                 explosionPool = new DrawablePool<DefaultHitExplosion>(5),
                 heartsplosionPool = new DrawablePool<HeartHitExplosion>(5),
@@ -188,6 +189,7 @@ namespace osu.Game.Rulesets.Rush.UI
                 healthTextPool = new DrawablePool<HealthText>(2),
             });
         }
+
         protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {
             base.OnNewDrawableHitObject(drawableHitObject);
@@ -200,15 +202,15 @@ namespace osu.Game.Rulesets.Rush.UI
 
         public override void Add(DrawableHitObject hitObject)
         {
-            if (hitObject is IDrawableLanedHit laned)
-            {
-                if (laned.Lane == LanedHitLane.Air)
-                    airLane.Add(hitObject);
-                else if (laned.Lane == LanedHitLane.Ground)
-                    groundLane.Add(hitObject);
+            if (!(hitObject is IDrawableLanedHit laned))
                 return;
-            }
+
+            if (laned.Lane == LanedHitLane.Air)
+                airLane.Add(hitObject);
+            else if (laned.Lane == LanedHitLane.Ground)
+                groundLane.Add(hitObject);
         }
+
         public override bool Remove(DrawableHitObject hitObject)
         {
             if (!base.Remove(hitObject))
@@ -220,7 +222,6 @@ namespace osu.Game.Rulesets.Rush.UI
             return true;
         }
 
-
         public override void Add(HitObject hitObject)
         {
             switch (hitObject)
@@ -229,6 +230,7 @@ namespace osu.Game.Rulesets.Rush.UI
                     playfieldForLane(laned.Lane).Add(hitObject);
                     return;
             }
+
             base.Add(hitObject);
         }
 
@@ -261,6 +263,7 @@ namespace osu.Game.Rulesets.Rush.UI
                 if (rushJudgedObject is IDrawableLanedHit laned)
                     playfieldForLane(laned.Lane).AddExplosion(explosion);
             }
+
             //const float judgement_time = 250f;
             // Display health point difference if the judgement result implies it.
             var pointDifference = rushResult.Judgement.HealthPointIncreaseFor(rushResult);

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -202,25 +202,35 @@ namespace osu.Game.Rulesets.Rush.UI
         [BackgroundDependencyLoader]
         private void load(TextureStore store)
         {
+            NewResult += onNewResult;
+
             RegisterPool<Minion, DrawableMinion>(8);
             RegisterPool<MiniBoss, DrawableMiniBoss>(4);
             RegisterPool<MiniBossTick, DrawableMiniBossTick>(10);
         }
-
-        public override void Add(DrawableHitObject hitObject)
+        protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {
-            hitObject.OnNewResult += onNewResult;
+            base.OnNewDrawableHitObject(drawableHitObject);
 
-            if (hitObject is DrawableMiniBoss drawableMiniBoss)
+            if (drawableHitObject is DrawableMiniBoss drawableMiniBoss)
                 drawableMiniBoss.Attacked += onMiniBossAttacked;
 
-            switch (hitObject)
+            switch (drawableHitObject)
             {
                 case DrawableRushHitObject drho:
                     proxiedHitObjects.Add(drho.CreateProxiedContent());
                     break;
             }
+        }
 
+        protected override void OnHitObjectAdded(HitObject hitObject)
+        {
+            base.OnHitObjectAdded(hitObject);
+        }
+
+
+        public override void Add(DrawableHitObject hitObject)
+        {
             base.Add(hitObject);
         }
 
@@ -228,8 +238,6 @@ namespace osu.Game.Rulesets.Rush.UI
         {
             if (!base.Remove(hitObject))
                 return false;
-
-            hitObject.OnNewResult -= onNewResult;
 
             if (hitObject is DrawableMiniBoss drawableMiniBoss)
                 drawableMiniBoss.Attacked -= onMiniBossAttacked;

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -7,7 +7,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Bindings;
 using osu.Game.Rulesets.Judgements;

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -318,13 +318,16 @@ namespace osu.Game.Rulesets.Rush.UI
                     case Sawblade sawblade:
                         judgementDrawable.StartPosition = new Vector2(0f, judgementPositionForLane(sawblade.Lane.Opposite()));
                         judgementDrawable.StartScale = new Vector2(1.2f);
-
                         break;
 
                     case LanedHit lanedHit:
                         judgementDrawable.StartPosition = new Vector2(0f, judgementPositionForLane(lanedHit.Lane));
                         judgementDrawable.StartScale = new Vector2(1.5f);
+                        break;
 
+                    case MiniBoss _:
+                        judgementDrawable.StartPosition = new Vector2(0f, judgementPositionForLane(LanedHitLane.Air));
+                        judgementDrawable.StartScale = new Vector2(1.5f);
                         break;
                 }
 

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -203,6 +203,8 @@ namespace osu.Game.Rulesets.Rush.UI
         private void load(TextureStore store)
         {
             RegisterPool<Minion, DrawableMinion>(8);
+            RegisterPool<MiniBoss, DrawableMiniBoss>(4);
+            RegisterPool<MiniBossTick, DrawableMiniBossTick>(10);
         }
 
         public override void Add(DrawableHitObject hitObject)

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -213,6 +213,7 @@ namespace osu.Game.Rulesets.Rush.UI
             RegisterPool<DualHit, DrawableDualHit>(8);
             RegisterPool<DualHitPart, DrawableDualHitPart>(16);
             RegisterPool<Sawblade, DrawableSawblade>(4);
+            RegisterPool<Heart, DrawableHeart>(2);
         }
         protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -207,6 +207,9 @@ namespace osu.Game.Rulesets.Rush.UI
             RegisterPool<Minion, DrawableMinion>(8);
             RegisterPool<MiniBoss, DrawableMiniBoss>(4);
             RegisterPool<MiniBossTick, DrawableMiniBossTick>(10);
+            RegisterPool<StarSheet, DrawableStarSheet>(8);
+            RegisterPool<StarSheetHead, DrawableStarSheetHead>(8);
+            RegisterPool<StarSheetTail, DrawableStarSheetTail>(8);
         }
         protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -212,6 +212,7 @@ namespace osu.Game.Rulesets.Rush.UI
             RegisterPool<StarSheetTail, DrawableStarSheetTail>(8);
             RegisterPool<DualHit, DrawableDualHit>(8);
             RegisterPool<DualHitPart, DrawableDualHitPart>(16);
+            RegisterPool<Sawblade, DrawableSawblade>(4);
         }
         protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -264,7 +264,6 @@ namespace osu.Game.Rulesets.Rush.UI
                     playfieldForLane(laned.Lane).AddExplosion(explosion);
             }
 
-            //const float judgement_time = 250f;
             // Display health point difference if the judgement result implies it.
             var pointDifference = rushResult.Judgement.HealthPointIncreaseFor(rushResult);
 

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -267,23 +268,8 @@ namespace osu.Game.Rulesets.Rush.UI
 
         private void onMiniBossAttacked(DrawableMiniBoss drawableMiniBoss, double timeOffset)
         {
-            // TODO: maybe this explosion can be moved into the mini boss drawable object itself.
-            var explosion = new DefaultHitExplosion(Color4.Yellow.Darken(0.5f))
-            {
-                Alpha = 0,
-                Depth = 0,
-                Origin = Anchor.Centre,
-                Anchor = drawableMiniBoss.Anchor,
-                Size = new Vector2(200, 200),
-                Scale = new Vector2(0.9f + RNG.NextSingle() * 0.2f) * 1.5f,
-                Rotation = RNG.NextSingle() * 360f,
-            };
 
-            halfPaddingOverEffectContainer.Add(explosion);
-
-            explosion.ScaleTo(explosion.Scale * 0.5f, 200f)
-                     .FadeOutFromOne(200f)
-                     .Expire(true);
+            halfPaddingOverEffectContainer.Add(explosionPool.Get(h => h.Apply(drawableMiniBoss)));
 
             PlayerSprite.Target = PlayerTargetLane.MiniBoss;
         }

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Rulesets.Rush.UI
         private DrawablePool<DefaultHitExplosion> explosionPool;
         private DrawablePool<HeartHitExplosion> heartsplosionPool;
         private DrawablePool<StarSheetHitExplosion> sheetsplosionPool;
+        private DrawablePool<HealthText> healthTextPool;
 
         public RushPlayfield()
         {
@@ -225,6 +226,7 @@ namespace osu.Game.Rulesets.Rush.UI
             explosionPool = new DrawablePool<DefaultHitExplosion>(5);
             heartsplosionPool = new DrawablePool<HeartHitExplosion>(5);
             sheetsplosionPool = new DrawablePool<StarSheetHitExplosion>(5);
+            healthTextPool = new DrawablePool<HealthText>(2);
         }
         protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {
@@ -293,8 +295,6 @@ namespace osu.Game.Rulesets.Rush.UI
 
             PlayerSprite.HandleResult(rushJudgedObject, result);
 
-            const float judgement_time = 250f;
-
             // Display hit explosions for objects that allow it.
             if (result.IsHit && rushJudgedObject.DisplayExplosion)
             {
@@ -321,26 +321,7 @@ namespace osu.Game.Rulesets.Rush.UI
             var pointDifference = rushResult.Judgement.HealthPointIncreaseFor(rushResult);
 
             if (pointDifference != 0)
-            {
-                var healthText = new SpriteText
-                {
-                    RelativePositionAxes = Axes.Both,
-                    Position = new Vector2(0.75f, 0.5f),
-                    Origin = Anchor.Centre,
-                    Colour = pointDifference > 0 ? Color4.Green : Color4.Red,
-                    Text = $"{pointDifference:+0;-0}",
-                    Font = FontUsage.Default.With(size: 40),
-                    Scale = new Vector2(1.2f),
-                };
-
-                overPlayerEffectsContainer.Add(healthText);
-
-                healthText.ScaleTo(1f, judgement_time)
-                          .Then()
-                          .FadeOutFromOne(judgement_time)
-                          .MoveToOffset(new Vector2(0f, -20f), judgement_time)
-                          .Expire(true);
-            }
+                overPlayerEffectsContainer.Add(healthTextPool.Get(h => h.Apply(pointDifference)));
 
             // Display judgement results in a drawable for objects that allow it.
             if (rushJudgedObject.DisplayResult)

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -7,7 +7,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Bindings;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
@@ -173,7 +172,7 @@ namespace osu.Game.Rulesets.Rush.UI
         }
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore store)
+        private void load()
         {
             RegisterPool<MiniBoss, DrawableMiniBoss>(4);
             RegisterPool<MiniBossTick, DrawableMiniBossTick>(10);
@@ -224,7 +223,12 @@ namespace osu.Game.Rulesets.Rush.UI
             switch (hitObject)
             {
                 case LanedHit laned:
-                    playfieldForLane(laned.Lane).Add(hitObject);
+                    laned.LaneBindable.BindValueChanged(lane =>
+                    {
+                        if (lane.OldValue != lane.NewValue)
+                            playfieldForLane(lane.OldValue).Remove(hitObject);
+                        playfieldForLane(lane.OldValue).Add(hitObject);
+                    }, true);
                     return;
             }
 

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -223,11 +223,13 @@ namespace osu.Game.Rulesets.Rush.UI
             RegisterPool<Sawblade, DrawableSawblade>(4);
             RegisterPool<Heart, DrawableHeart>(2);
 
-            judgementPool = new DrawablePool<DrawableRushJudgement>(5);
-            explosionPool = new DrawablePool<DefaultHitExplosion>(5);
-            heartsplosionPool = new DrawablePool<HeartHitExplosion>(5);
-            sheetsplosionPool = new DrawablePool<StarSheetHitExplosion>(5);
-            healthTextPool = new DrawablePool<HealthText>(2);
+            AddRangeInternal(new Drawable[]{
+                judgementPool = new DrawablePool<DrawableRushJudgement>(5),
+                explosionPool = new DrawablePool<DefaultHitExplosion>(5),
+                heartsplosionPool = new DrawablePool<HeartHitExplosion>(5),
+                sheetsplosionPool = new DrawablePool<StarSheetHitExplosion>(5),
+                healthTextPool = new DrawablePool<HealthText>(2),
+            });
         }
         protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {
@@ -312,23 +314,21 @@ namespace osu.Game.Rulesets.Rush.UI
             // Display judgement results in a drawable for objects that allow it.
             if (rushJudgedObject.DisplayResult)
             {
-                DrawableJudgement judgementDrawable = judgementPool.Get(j => j.Apply(result, judgedObject));
+                DrawableRushJudgement judgementDrawable = judgementPool.Get(j => j.Apply(result, judgedObject));
 
                 // TODO: showing judgements based on the judged object suggests that
                 //       this may want to be inside the object class as well.
                 switch (rushJudgedObject.HitObject)
                 {
                     case Sawblade sawblade:
-                        judgementDrawable.Origin = Anchor.Centre;
-                        judgementDrawable.Position = new Vector2(0f, judgementPositionForLane(sawblade.Lane.Opposite()));
-                        judgementDrawable.Scale = new Vector2(1.2f);
+                        judgementDrawable.StartPosition = new Vector2(0f, judgementPositionForLane(sawblade.Lane.Opposite()));
+                        judgementDrawable.StartScale = new Vector2(1.2f);
 
                         break;
 
                     case LanedHit lanedHit:
-                        judgementDrawable.Origin = Anchor.Centre;
-                        judgementDrawable.Position = new Vector2(0f, judgementPositionForLane(lanedHit.Lane));
-                        judgementDrawable.Scale = new Vector2(1.5f);
+                        judgementDrawable.StartPosition = new Vector2(0f, judgementPositionForLane(lanedHit.Lane));
+                        judgementDrawable.StartScale = new Vector2(1.5f);
 
                         break;
                 }

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -56,8 +56,8 @@ namespace osu.Game.Rulesets.Rush.UI
 
         private DrawablePool<DrawableRushJudgement> judgementPool;
         private DrawablePool<DefaultHitExplosion> explosionPool;
-        private DrawablePool<StarSheetHitExplosion> sheetsplosionPool;
-        private DrawablePool<HeartHitExplosion> heartsplosionPool;
+        private DrawablePool<StarSheetHitExplosion> sheetExplosionPool;
+        private DrawablePool<HeartHitExplosion> heartExplosionPool;
         private DrawablePool<HealthText> healthTextPool;
 
         [Cached]
@@ -184,8 +184,8 @@ namespace osu.Game.Rulesets.Rush.UI
             {
                 judgementPool = new DrawablePool<DrawableRushJudgement>(5),
                 explosionPool = new DrawablePool<DefaultHitExplosion>(15),
-                sheetsplosionPool = new DrawablePool<StarSheetHitExplosion>(10),
-                heartsplosionPool = new DrawablePool<HeartHitExplosion>(2),
+                sheetExplosionPool = new DrawablePool<StarSheetHitExplosion>(10),
+                heartExplosionPool = new DrawablePool<HeartHitExplosion>(2),
                 healthTextPool = new DrawablePool<HealthText>(2),
             });
         }
@@ -254,9 +254,9 @@ namespace osu.Game.Rulesets.Rush.UI
             {
                 Drawable explosion = rushJudgedObject switch
                 {
-                    DrawableStarSheetHead head => sheetsplosionPool.Get(s => s.Apply(head)),
-                    DrawableStarSheetTail tail => sheetsplosionPool.Get(s => s.Apply(tail)),
-                    DrawableHeart heart => heartsplosionPool.Get(h => h.Apply(heart)),
+                    DrawableStarSheetHead head => sheetExplosionPool.Get(s => s.Apply(head)),
+                    DrawableStarSheetTail tail => sheetExplosionPool.Get(s => s.Apply(tail)),
+                    DrawableHeart heart => heartExplosionPool.Get(h => h.Apply(heart)),
                     _ => explosionPool.Get(h => h.Apply(rushJudgedObject)),
                 };
 

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -47,6 +47,9 @@ namespace osu.Game.Rulesets.Rush.UI
         private readonly JudgementContainer<DrawableJudgement> judgementContainer;
 
         private DrawablePool<DrawableRushJudgement> judgementPool;
+        private DrawablePool<DefaultHitExplosion> explosionPool;
+        private DrawablePool<HeartHitExplosion> heartsplosionPool;
+        private DrawablePool<StarSheetHitExplosion> sheetsplosionPool;
 
         public RushPlayfield()
         {
@@ -219,6 +222,9 @@ namespace osu.Game.Rulesets.Rush.UI
             RegisterPool<Heart, DrawableHeart>(2);
 
             judgementPool = new DrawablePool<DrawableRushJudgement>(5);
+            explosionPool = new DrawablePool<DefaultHitExplosion>(5);
+            heartsplosionPool = new DrawablePool<HeartHitExplosion>(5);
+            sheetsplosionPool = new DrawablePool<StarSheetHitExplosion>(5);
         }
         protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {
@@ -292,7 +298,13 @@ namespace osu.Game.Rulesets.Rush.UI
             // Display hit explosions for objects that allow it.
             if (result.IsHit && rushJudgedObject.DisplayExplosion)
             {
-                var explosion = rushJudgedObject.CreateHitExplosion();
+                Drawable explosion = rushJudgedObject switch
+                {
+                    DrawableStarSheetHead head => sheetsplosionPool.Get(s => s.Apply(head)),
+                    DrawableStarSheetTail tail => sheetsplosionPool.Get(s => s.Apply(tail)),
+                    DrawableHeart heart => heartsplosionPool.Get(h => h.Apply(heart)),
+                    _ => explosionPool.Get(h => h.Apply(rushJudgedObject)),
+                };
 
                 if (explosion != null)
                 {

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -1,16 +1,12 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Bindings;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -22,7 +18,6 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Rush.UI
 {

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -205,10 +205,7 @@ namespace osu.Game.Rulesets.Rush.UI
             if (!(hitObject is IDrawableLanedHit laned))
                 return;
 
-            if (laned.Lane == LanedHitLane.Air)
-                airLane.Add(hitObject);
-            else if (laned.Lane == LanedHitLane.Ground)
-                groundLane.Add(hitObject);
+            playfieldForLane(laned.Lane).Add(hitObject);
         }
 
         public override bool Remove(DrawableHitObject hitObject)

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Judgements;
 using osu.Game.Rulesets.Rush.Objects;
@@ -201,6 +202,7 @@ namespace osu.Game.Rulesets.Rush.UI
         [BackgroundDependencyLoader]
         private void load(TextureStore store)
         {
+            RegisterPool<Minion, DrawableMinion>(8);
         }
 
         public override void Add(DrawableHitObject hitObject)

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -199,25 +199,6 @@ namespace osu.Game.Rulesets.Rush.UI
             ((DrawableRushHitObject)drawableHitObject).CheckHittable = hitPolicy.IsHittable;
         }
 
-        public override void Add(DrawableHitObject hitObject)
-        {
-            if (!(hitObject is IDrawableLanedHit laned))
-                return;
-
-            playfieldForLane(laned.Lane).Add(hitObject);
-        }
-
-        public override bool Remove(DrawableHitObject hitObject)
-        {
-            if (!base.Remove(hitObject))
-                return false;
-
-            if (hitObject is DrawableMiniBoss drawableMiniBoss)
-                drawableMiniBoss.Attacked -= onMiniBossAttacked;
-
-            return true;
-        }
-
         public override void Add(HitObject hitObject)
         {
             switch (hitObject)

--- a/osu.Game.Rulesets.Rush/UI/StarSheetHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/StarSheetHitExplosion.cs
@@ -23,15 +23,15 @@ namespace osu.Game.Rulesets.Rush.UI
 
             InternalChildren = new Drawable[]
             {
-                    explosionStar = new StarSheetCapStarPiece(),
-                    flashCircle = new Circle
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Alpha = 0.4f,
-                        RelativeSizeAxes = Axes.Both,
-                        Scale = new Vector2(0.5f),
-                    }
+                explosionStar = new StarSheetCapStarPiece(),
+                flashCircle = new Circle
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Alpha = 0.4f,
+                    RelativeSizeAxes = Axes.Both,
+                    Scale = new Vector2(0.5f),
+                }
             };
         }
 

--- a/osu.Game.Rulesets.Rush/UI/StarSheetHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/StarSheetHitExplosion.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Rush.Objects.Drawables;
+using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
+using osuTK;
+
+namespace osu.Game.Rulesets.Rush.UI
+{
+    public class StarSheetHitExplosion : PoolableDrawable
+    {
+        private readonly StarSheetCapStarPiece explosionStar;
+        private readonly Circle flashCircle;
+
+        public StarSheetHitExplosion()
+        {
+            Origin = Anchor.Centre;
+
+            InternalChildren = new Drawable[]
+            {
+                    explosionStar = new StarSheetCapStarPiece(),
+                    flashCircle = new Circle
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Alpha = 0.4f,
+                        RelativeSizeAxes = Axes.Both,
+                        Scale = new Vector2(0.5f),
+                    }
+            };
+        }
+
+        public void Apply(Drawable drawable)
+        {
+            IDrawableLanedHit laned = (IDrawableLanedHit)drawable;
+            Anchor = laned.LaneAnchor;
+            Size = drawable.Size;
+            flashCircle.Colour = laned.LaneAccentColour.Lighten(0.5f);
+        }
+
+        protected override void PrepareForUse()
+        {
+            base.PrepareForUse();
+
+            explosionStar.ScaleTo(1)
+                         .ScaleTo(2f, RushPlayfield.HIT_EXPLOSION_DURATION)
+                         .FadeOutFromOne(RushPlayfield.HIT_EXPLOSION_DURATION)
+                         .Expire(true);
+
+            flashCircle.ScaleTo(0.5f).FadeTo(0.4f)
+                       .ScaleTo(4f, RushPlayfield.HIT_EXPLOSION_DURATION / 2)
+                       .Then()
+                       .ScaleTo(0.5f, RushPlayfield.HIT_EXPLOSION_DURATION / 2)
+                       .FadeOut(RushPlayfield.HIT_EXPLOSION_DURATION / 2)
+                       .Expire(true);
+
+            this.Delay(RushPlayfield.HIT_EXPLOSION_DURATION).Expire(true);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/UI/StarSheetHitExplosion.cs
+++ b/osu.Game.Rulesets.Rush/UI/StarSheetHitExplosion.cs
@@ -5,6 +5,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
 using osuTK;
@@ -35,7 +36,7 @@ namespace osu.Game.Rulesets.Rush.UI
             };
         }
 
-        public void Apply(Drawable drawable)
+        public void Apply(DrawableHitObject drawable)
         {
             IDrawableLanedHit laned = (IDrawableLanedHit)drawable;
             Size = drawable.Size;


### PR DESCRIPTION
* [x] Depends on #131 
* [x] Extra adjustments to make full use of #131 

Resolves #59
Fixes #25 

I've made pooling work for each HitObject and nested HitObjects, along with explosions, judgements, and the health text. I tried to not touch anything irrelevant or do anything that I would consider out of scope for this PR.

## Encountered problems: 

~~Some objects and properties aren't lane agnostic, while most objects are fine in this regard, I find the anchor adjustments to be a bit ugly. `MinionPiece` also changes sprites based on the lane the DHO is in, and [I've made it so that it updates its animation set when the DHO has a new applied HitObject](https://github.com/LumpBloom7/rush/blob/4a3484334abd1418d2eec9ab77c0ba3ef35ca99c/osu.Game.Rulesets.Rush/Objects/Drawables/Pieces/MinionPiece.cs#L39). These issues, as mentioned earlier, could be completely alleviated with nested playfields.~~ With the use of nested playfields, we now preassign a lane to the newly created DHO, so that the piece will load in the proper textures. This DHO will always be used in the same lane, so we don't need to reapply the visuals on every use now.

Next problem I couldn't really get my head around. The `MinionPiece` occasionally appears invisible when proxying is used within `DrawableMinion`, and very inconsistent at that. The `TextureAnimation` drawable is being masked for some reason, and that is worth investigating imo. I've chosen to comment out the proxying code, since that keeps everything functional for now. The whole proxying code can also be removed imo seeing as the HitObjectContainer is reverse-ordered, and that the proxy layer is right on top of HOC, rendering it a redundant procedure.

~~I'm also not happy with how I went about with dealing with the non-DHO poolables, mainly the various explosions. I wanted to centralize the initialization of each to the `Apply()` methods, but some had a dependance of a parent's DrawSize. Some of the transforms are also not lane agnostic, meaning some more transforms are added to ensure the proper state before the real-deal. (otherwise a judgement text may animate in a different lane)~~ Most of these are now lane agnostic, the lane is responsible for their positioning now.

