### PR TITLE
Distinguish rush! release builds from development builds

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -17,11 +17,11 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Development --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: Rush
-        path: osu.Game.Rulesets.Rush/bin/Release/netstandard2.1/osu.Game.Rulesets.Rush.dll
+        name: Rush (dev build)
+        path: osu.Game.Rulesets.Rush/bin/Development/netstandard2.1/osu.Game.Rulesets.Rush-dev.dll

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,5 +25,17 @@
             "preLaunchTask": "Build tests (Release)",
             "console": "internalConsole"
         },
+        {
+            "name": "Rush for osu! (Tests, Development)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": [
+                "${workspaceRoot}/osu.Game.Rulesets.Rush.Tests/bin/Development/net5.0/osu.Game.Rulesets.Rush.Tests.dll"
+            ],
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "Build tests (Development)",
+            "console": "internalConsole"
+        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,6 +30,21 @@
             "group": "build",
             "problemMatcher": "$msCompile"
         },
+        {
+            "label": "Build tests (Development)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "osu.Game.Rulesets.Rush.Tests",
+                "/p:Configuration=Development",
+                "/p:GenerateFullPaths=true",
+                "/m",
+                "/verbosity:m"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
         // Test Tasks
         {
             "label": "Run tests (Debug)",

--- a/osu.Game.Rulesets.Rush.Tests/osu.Game.Rulesets.Rush.Tests.csproj
+++ b/osu.Game.Rulesets.Rush.Tests/osu.Game.Rulesets.Rush.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
       <StartupObject>osu.Game.Rulesets.Rush.Tests.VisualTestRunner</StartupObject>
+      <Configurations>Debug;Release;Development</Configurations>
+      <Platforms>AnyCPU</Platforms>
     </PropertyGroup>
     <ItemGroup Label="Service">
       <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
@@ -17,6 +19,9 @@
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Development' ">
+    <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game.Rulesets.Rush\osu.Game.Rulesets.Rush.csproj" />

--- a/osu.Game.Rulesets.Rush.sln
+++ b/osu.Game.Rulesets.Rush.sln
@@ -11,21 +11,21 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		VisualTests|Any CPU = VisualTests|Any CPU
+		Development|Any CPU = Development|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.VisualTests|Any CPU.ActiveCfg = Release|Any CPU
-		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.VisualTests|Any CPU.Build.0 = Release|Any CPU
+		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Development|Any CPU.ActiveCfg = Development|Any CPU
+		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Development|Any CPU.Build.0 = Development|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.VisualTests|Any CPU.ActiveCfg = Debug|Any CPU
-		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.VisualTests|Any CPU.Build.0 = Debug|Any CPU
+		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Development|Any CPU.ActiveCfg = Development|Any CPU
+		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Development|Any CPU.Build.0 = Development|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -106,14 +106,40 @@ namespace osu.Game.Rulesets.Rush
                         Origin = Anchor.Centre,
                         Icon = FontAwesome.Regular.Circle,
                     },
-                    new SpriteIcon
+                };
+
+                if (!RushRuleset.IsDevelopmentBuild)
+                {
+                    AddInternal(new SpriteIcon
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Scale = new Vector2(0.6f),
                         Icon = FontAwesome.Solid.Running,
-                    }
-                };
+                    });
+                }
+                else
+                {
+                    AddRangeInternal(new[]
+                    {
+                        new SpriteIcon
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Scale = new Vector2(0.4f),
+                            Icon = FontAwesome.Solid.Running,
+                            Margin = new MarginPadding { Bottom = 0.5f, Right = 0.5f },
+                        },
+                        new SpriteIcon
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Scale = new Vector2(0.4f),
+                            Icon = FontAwesome.Solid.Wrench,
+                            Margin = new MarginPadding { Top = 0.5f, Left = 0.5f },
+                        }
+                    });
+                }
             }
         }
     }

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -22,15 +24,17 @@ namespace osu.Game.Rulesets.Rush
 {
     public class RushRuleset : Ruleset
     {
-        public const string DESCRIPTION = "Rush!";
-        public const string PLAYING_VERB = "Punching doods";
         public const string SHORT_NAME = "rush";
 
-        public override string Description => DESCRIPTION;
+        private static readonly Lazy<bool> is_development_build = new Lazy<bool>(() => typeof(RushRuleset).Assembly.GetName().Name.EndsWith("-dev"));
 
-        public override string PlayingVerb => PLAYING_VERB;
+        public static bool IsDevelopmentBuild => is_development_build.Value;
 
-        public override string ShortName => SHORT_NAME;
+        public override string ShortName => !IsDevelopmentBuild ? SHORT_NAME : $"{SHORT_NAME}-dev";
+
+        public override string Description => !IsDevelopmentBuild ? "Rush!" : "Rush! (dev build)";
+
+        public override string PlayingVerb => "Punching doods";
 
         public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new DrawableRushRuleset(this, beatmap, mods);
 

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -29,7 +29,7 @@
          and we change that based on the build configuration for separation purposes.
          Therefore prepend the AssemblyName to embedded resources names instead. -->
     <EmbeddedResource Include="Resources\**">
-      <LogicalName>$(AssemblyName).$([System.String]::Copy(&quot;%(Identity)&quot;).Replace($([System.IO.Path]::DirectorySeparatorChar.ToString()),&quot;.&quot;))</LogicalName>
+      <LogicalName>$(AssemblyName).$([System.String]::Copy(%(Identity)).Replace($([System.IO.Path]::DirectorySeparatorChar.ToString()), '.'))</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -1,30 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+  <PropertyGroup Label="Project">
     <Configurations>Debug;Release;Development</Configurations>
-    <Platforms>AnyCPU</Platforms>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <OutputType>Library</OutputType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <RootNamespace>osu.Game.Rulesets.Rush</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Development' ">
     <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
   </PropertyGroup>
   <Choose>
     <When Condition=" '$(Configuration)' == 'Release' ">
-      <PropertyGroup Label="Project">
-        <TargetFramework>netstandard2.1</TargetFramework>
+      <PropertyGroup>
         <AssemblyName>osu.Game.Rulesets.Rush</AssemblyName>
         <AssemblyTitle>rush for osu!</AssemblyTitle>
-        <OutputType>Library</OutputType>
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <RootNamespace>osu.Game.Rulesets.Rush</RootNamespace>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>osu.Game.Rulesets.Rush-dev</AssemblyName>
         <AssemblyTitle>rush for osu! (development build)</AssemblyTitle>
-        <OutputType>Library</OutputType>
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <RootNamespace>osu.Game.Rulesets.Rush</RootNamespace>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -24,7 +24,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <!-- The automated version of this (<EmbeddedResource Include="xyz />) would prepend the RootNamespace to name,
+    <!-- The automated version of this (<EmbeddedResource Include="xyz\**" />) would prepend the RootNamespace to name,
          that will not work well with DllResourceStore as it can only determine the root namespace via AssemblyName,
          and we change that based on the build configuration for separation purposes.
          Therefore prepend the AssemblyName to embedded resources names instead. -->

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -24,7 +24,13 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\**" />
+    <!-- The automated version of this (<EmbeddedResource Include="xyz />) would prepend the RootNamespace to name,
+         that will not work well with DllResourceStore as it can only determine the root namespace via AssemblyName,
+         and we change that based on the build configuration for separation purposes.
+         Therefore prepend the AssemblyName to embedded resources names instead. -->
+    <EmbeddedResource Include="Resources\**">
+      <LogicalName>$(AssemblyName).$([System.String]::Copy(&quot;%(Identity)&quot;).Replace(&quot;/&quot;,&quot;.&quot;))</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game" Version="2021.323.0" />

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -33,6 +33,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2021.323.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2021.406.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -29,7 +29,7 @@
          and we change that based on the build configuration for separation purposes.
          Therefore prepend the AssemblyName to embedded resources names instead. -->
     <EmbeddedResource Include="Resources\**">
-      <LogicalName>$(AssemblyName).$([System.String]::Copy(&quot;%(Identity)&quot;).Replace(&quot;/&quot;,&quot;.&quot;))</LogicalName>
+      <LogicalName>$(AssemblyName).$([System.String]::Copy(&quot;%(Identity)&quot;).Replace($([System.IO.Path]::DirectorySeparatorChar.ToString()),&quot;.&quot;))</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -1,11 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Label="Project">
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyTitle>osu.Game.Rulesets.Rush</AssemblyTitle>
-    <OutputType>Library</OutputType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <RootNamespace>osu.Game.Rulesets.Rush</RootNamespace>
+  <PropertyGroup>
+    <Configurations>Debug;Release;Development</Configurations>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Development' ">
+    <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
+  </PropertyGroup>
+  <Choose>
+    <When Condition=" '$(Configuration)' == 'Release' ">
+      <PropertyGroup Label="Project">
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <AssemblyName>osu.Game.Rulesets.Rush</AssemblyName>
+        <AssemblyTitle>rush for osu!</AssemblyTitle>
+        <OutputType>Library</OutputType>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <RootNamespace>osu.Game.Rulesets.Rush</RootNamespace>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <AssemblyName>osu.Game.Rulesets.Rush-dev</AssemblyName>
+        <AssemblyTitle>rush for osu! (development build)</AssemblyTitle>
+        <OutputType>Library</OutputType>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <RootNamespace>osu.Game.Rulesets.Rush</RootNamespace>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <EmbeddedResource Include="Resources\**" />
   </ItemGroup>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/12259
- [x] Depends on game bump

This is done for the sole reason of being able to load a development rush! build side by side with an official release build, for comparing things between pretty quickly and identify bugs without having to resort to exiting the game, switching to master, etc..

![image](https://user-images.githubusercontent.com/22781491/113211753-951a5e80-927e-11eb-83b9-9a6f01203fdf.png)

Builds generated by CI through artifacts now use a special configuration named `Development`, which is optimized like your usual release config, but falls down within the development builds.

- In the above image, the ruleset displayed description below the selector button is rather unfortunate, but can't be helped within our scope.