### PR TITLE
Fix DualHits providing 3 judgements instead of two

### DIFF
--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
@@ -80,44 +80,16 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             Origin = e.NewValue == ScrollingDirection.Left ? Anchor.CentreLeft : Anchor.CentreRight;
         }
 
-        public override bool OnPressed(RushAction action)
-        {
-            if (AllJudged)
-                return false;
-
-            var airResult = !Air.AllJudged && Air.LaneMatchesAction(action) && Air.UpdateResult(true);
-            var groundResult = !Ground.AllJudged && Ground.LaneMatchesAction(action) && Ground.UpdateResult(true);
-
-            if (Air.AllJudged && Ground.AllJudged)
-                return UpdateResult(true);
-
-            return airResult || groundResult;
-        }
+        // Input are handled by the DualHit parts, since they still act like normal minions
+        public override bool OnPressed(RushAction action) => false;
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
-            if (AllJudged)
-                return;
+            if (AllJudged) return;
 
-            if (!userTriggered && timeOffset < 0)
-                return;
-
-            if (!Ground.AllJudged)
-                Ground.UpdateResult(false);
-
-            if (!Air.AllJudged)
-                Air.UpdateResult(false);
-
-            if (Air.Result.Type == HitResult.None || Ground.Result.Type == HitResult.None)
-                return;
-
-            // If we missed either, it's an overall miss.
-            // If we hit both, the overall judgement is the lowest score of the two.
-            ApplyResult(r =>
-            {
-                var lowestResult = Air.Result.Type < Ground.Result.Type ? Air.Result.Type : Ground.Result.Type;
-                r.Type = !Air.IsHit && !Ground.IsHit ? r.Judgement.MinResult : lowestResult;
-            });
+            // We can judge this object the instant the nested objects are judged
+            if (Air.AllJudged && Ground.AllJudged)
+                ApplyResult(r => r.Type = (Air.IsHit && Ground.IsHit) ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
@@ -2,9 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -23,12 +23,6 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         }
 
         public new bool UpdateResult(bool userTriggered) => base.UpdateResult(userTriggered);
-
-        public override bool OnPressed(RushAction action) => false;
-
-        public override void OnReleased(RushAction action)
-        {
-        }
 
         protected override void UpdateHitStateTransforms(ArmedState state)
         {

--- a/osu.Game.Rulesets.Rush/Objects/DualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/DualHit.cs
@@ -2,6 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Threading;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Rush.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Rush.Objects
 {
@@ -19,6 +22,10 @@ namespace osu.Game.Rulesets.Rush.Objects
 
         public readonly DualHitPart Air = new DualHitPart { Lane = LanedHitLane.Air };
         public readonly DualHitPart Ground = new DualHitPart { Lane = LanedHitLane.Ground };
+
+        public override Judgement CreateJudgement() => new RushIgnoreJudgement();
+
+        protected override HitWindows CreateHitWindows() => HitWindows.Empty;
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
As simple as it gets, though I did do some minor tweaks to shift input handling and result application responsibility to the DualHitParts, and made the parent do the bare minimum required.