### PR TITLE
Remove unused HitResults from results card

### DIFF
--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -94,6 +94,17 @@ namespace osu.Game.Rulesets.Rush
 
         public override Drawable CreateIcon() => new RushIcon();
 
+
+        protected override IEnumerable<HitResult> GetValidHitResults()
+        {
+            return new[]
+            {
+                HitResult.Perfect,
+                HitResult.Great,
+            };
+        }
+
+
         public class RushIcon : CompositeDrawable
         {
             public RushIcon()


### PR DESCRIPTION
By overriding the list of valid results in `RushRuleset`, we are able to prevent osu from listing all HitResults in the post-game score card.
![image](https://user-images.githubusercontent.com/12001167/114700088-5f1ab700-9d21-11eb-895f-b8b7604768a5.png)
