### PR TITLE
Shift judgement range to GREAT/GOOD from PERFECT/GREAT

### DIFF
--- a/osu.Game.Rulesets.Rush/Judgements/RushJudgement.cs
+++ b/osu.Game.Rulesets.Rush/Judgements/RushJudgement.cs
@@ -9,6 +9,8 @@ namespace osu.Game.Rulesets.Rush.Judgements
 {
     public class RushJudgement : Judgement
     {
+        public override HitResult MaxResult => HitResult.Great;
+
         /// <summary>
         /// Retrieves the numeric health point increase of a <see cref="RushJudgementResult"/>.
         /// </summary>

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
@@ -129,9 +129,9 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                 }
 
                 var hitResult = numHits == HitObject.RequiredHits
-                    ? HitResult.Perfect
+                    ? HitResult.Great
                     : numHits > HitObject.RequiredHits / 2
-                        ? HitResult.Great
+                        ? HitResult.Good
                         : HitResult.Miss;
 
                 ApplyResult(r => r.Type = hitResult);

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -98,8 +98,8 @@ namespace osu.Game.Rulesets.Rush
         {
             return new[]
             {
-                HitResult.Perfect,
                 HitResult.Great,
+                HitResult.Good,
             };
         }
 

--- a/osu.Game.Rulesets.Rush/Scoring/HeartHitWindows.cs
+++ b/osu.Game.Rulesets.Rush/Scoring/HeartHitWindows.cs
@@ -9,10 +9,10 @@ namespace osu.Game.Rulesets.Rush.Scoring
     {
         protected override DifficultyRange[] GetRanges() => new[]
         {
-            new DifficultyRange(HitResult.Perfect, 50, 50, 50),
+            new DifficultyRange(HitResult.Great, 50, 50, 50),
             new DifficultyRange(HitResult.Miss, 200, 200, 200)
         };
 
-        public override bool IsHitResultAllowed(HitResult result) => result == HitResult.Perfect || result == HitResult.Miss;
+        public override bool IsHitResultAllowed(HitResult result) => result == HitResult.Great || result == HitResult.Miss;
     }
 }

--- a/osu.Game.Rulesets.Rush/Scoring/RushHitWindows.cs
+++ b/osu.Game.Rulesets.Rush/Scoring/RushHitWindows.cs
@@ -9,8 +9,8 @@ namespace osu.Game.Rulesets.Rush.Scoring
     {
         protected override DifficultyRange[] GetRanges() => new[]
         {
-            new DifficultyRange(HitResult.Perfect, 80, 50, 20),
-            new DifficultyRange(HitResult.Great, 160, 120, 80),
+            new DifficultyRange(HitResult.Great, 80, 50, 20),
+            new DifficultyRange(HitResult.Good, 160, 120, 80),
             new DifficultyRange(HitResult.Miss, 200, 180, 160),
         };
 
@@ -18,8 +18,8 @@ namespace osu.Game.Rulesets.Rush.Scoring
             result switch
             {
                 HitResult.Miss => true,
+                HitResult.Good => true,
                 HitResult.Great => true,
-                HitResult.Perfect => true,
                 _ => false
             };
     }

--- a/osu.Game.Rulesets.Rush/Scoring/SawbladeHitWindows.cs
+++ b/osu.Game.Rulesets.Rush/Scoring/SawbladeHitWindows.cs
@@ -9,10 +9,10 @@ namespace osu.Game.Rulesets.Rush.Scoring
     {
         protected override DifficultyRange[] GetRanges() => new[]
         {
-            new DifficultyRange(HitResult.Perfect, 20, 20, 20),
+            new DifficultyRange(HitResult.Great, 20, 20, 20),
             new DifficultyRange(HitResult.Miss, 50, 50, 50)
         };
 
-        public override bool IsHitResultAllowed(HitResult result) => result == HitResult.Perfect || result == HitResult.Miss;
+        public override bool IsHitResultAllowed(HitResult result) => result == HitResult.Great || result == HitResult.Miss;
     }
 }


### PR DESCRIPTION
https://github.com/ppy/osu/pull/12294 reduced the value of PERFECT judgements down to 315 from 350. Because of this, GREAT judgements are now worth ~95% acc, up from ~85% making it way too easy to maintain a high acc even with many mistakes.

I've adjusted the judgements so that GREAT/GOOD is used instead, which are worth 300 and 200 respectively, and changes their acc values to 100%/66.6%. This does make it a tad harder to maintain a high acc when compared to our results before the judgement updates.

If we want to present these judgements as if they are PERFECT/GREAT to the player, we could consider changing what text the judgements show (`result.GetRushJudgementText()` ), and change what the scorecard shows by overriding `Ruleset.GetDisplayNameForResult()`.