### PR TITLE
Add miss animations to Minions and DualHitParts

### DIFF
--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
@@ -37,13 +38,9 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Miss:
-                    const float miss_time = 150;
-                    this.FadeColour(Color4.Red, miss_time)
-                        .MoveToY(100, miss_time)
-                        .RotateTo(-45, miss_time)
-                        .FadeOut(miss_time);
+                    const float miss_time = 100;
+                    this.FadeColour(Color4.DarkGray.Darken(0.9f), miss_time);
                     break;
-
 
                 case ArmedState.Hit:
                     float travelY = 400f * (HitObject.Lane == LanedHitLane.Air ? -1 : 1);

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
@@ -38,8 +38,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Miss:
-                    const float miss_time = 100;
-                    this.FadeColour(Color4.DarkGray.Darken(0.9f), miss_time);
+                    this.FadeColour(Color4.DarkGray.Darken(0.9f), 100);
                     break;
 
                 case ArmedState.Hit:

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
 {
@@ -36,8 +37,13 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Miss:
-                    this.FadeOut(animation_time);
+                    const float miss_time = 150;
+                    this.FadeColour(Color4.Red, miss_time)
+                        .MoveToY(100, miss_time)
+                        .RotateTo(-45, miss_time)
+                        .FadeOut(miss_time);
                     break;
+
 
                 case ArmedState.Hit:
                     float travelY = 400f * (HitObject.Lane == LanedHitLane.Air ? -1 : 1);

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
@@ -58,8 +58,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Miss:
-                    const float miss_time = 100;
-                    this.FadeColour(Color4.DarkGray.Darken(0.9f), miss_time);
+                    this.FadeColour(Color4.DarkGray.Darken(0.9f), 100);
                     break;
 
                 case ArmedState.Hit:

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
@@ -57,11 +58,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Miss:
-                    const float miss_time = 150;
-                    this.FadeColour(Color4.Red, miss_time)
-                        .MoveToY(100, miss_time)
-                        .RotateTo(-45, miss_time)
-                        .FadeOut(miss_time);
+                    const float miss_time = 100;
+                    this.FadeColour(Color4.DarkGray.Darken(0.9f), miss_time);
                     break;
 
                 case ArmedState.Hit:

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMinion.cs
@@ -9,6 +9,7 @@ using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Rush.Objects.Drawables
 {
@@ -55,6 +56,14 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
             switch (state)
             {
+                case ArmedState.Miss:
+                    const float miss_time = 150;
+                    this.FadeColour(Color4.Red, miss_time)
+                        .MoveToY(100, miss_time)
+                        .RotateTo(-45, miss_time)
+                        .FadeOut(miss_time);
+                    break;
+
                 case ArmedState.Hit:
                     const float gravity_time = 300;
                     float randomness = -0.5f + (float)random.NextDouble();


### PR DESCRIPTION
As discussed [on discord](https://discord.com/channels/741467017923788900/825687815734951956/831157320116994068), the Minions and DualHitParts do not visibly react to players hitting them early. This makes it seem like they should still be hittable, while they are in fact not accepting nor blocking any input, causing a chain reaction of missed notes because the player keeps attempting to hit that note. It is what I believe is giving players the feeling that random misses are occuring, instead of it being the fault of HitWindows.

I've added a basic animation that plays whenever the object is missed, so that players are notified of their mistakes, and that they should adjust their timing. 


https://user-images.githubusercontent.com/12001167/115126063-b3958f00-9fcc-11eb-8427-544efa84e2a4.mp4

