### PR TITLE
Add FL, PF, SD, Wind Up, Wind Down

### DIFF
--- a/osu.Game.Rulesets.Rush/Mods/RushModFlashlight.cs
+++ b/osu.Game.Rulesets.Rush/Mods/RushModFlashlight.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Layout;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Rush.Objects;
+using osu.Game.Rulesets.Rush.UI;
+using osu.Game.Rulesets.UI;
+using osuTK;
+
+namespace osu.Game.Rulesets.Rush.Mods
+{
+    public class RushModFlashlight : ModFlashlight<RushHitObject>
+    {
+        public override double ScoreMultiplier => 1.12;
+
+        private const float default_flashlight_size = 330;
+
+        public override Flashlight CreateFlashlight() => new RushFlashlight(playfield);
+
+        private RushPlayfield playfield;
+
+        public override void ApplyToDrawableRuleset(DrawableRuleset<RushHitObject> drawableRuleset)
+        {
+            playfield = (RushPlayfield)drawableRuleset.Playfield;
+            base.ApplyToDrawableRuleset(drawableRuleset);
+        }
+
+        private class RushFlashlight : Flashlight
+        {
+            private readonly LayoutValue flashlightProperties = new LayoutValue(Invalidation.DrawSize);
+            private readonly RushPlayfield rushPlayfield;
+
+            public RushFlashlight(RushPlayfield rushPlayfield)
+            {
+                this.rushPlayfield = rushPlayfield;
+                FlashlightSize = new Vector2(0, getSizeFor(0));
+
+                AddLayout(flashlightProperties);
+            }
+
+            private float getSizeFor(int combo)
+            {
+                if (combo > 200)
+                    return default_flashlight_size * 0.8f;
+                else if (combo > 100)
+                    return default_flashlight_size * 0.9f;
+                else
+                    return default_flashlight_size;
+            }
+
+            protected override void OnComboChange(ValueChangedEvent<int> e)
+            {
+                this.TransformTo(nameof(FlashlightSize), new Vector2(0, getSizeFor(e.NewValue)), FLASHLIGHT_FADE_DURATION);
+            }
+
+            protected override string FragmentShader => "CircularFlashlight";
+
+            protected override void Update()
+            {
+                base.Update();
+
+                if (!flashlightProperties.IsValid)
+                {
+                    var flashlightPosition = rushPlayfield.OverPlayerEffectsContainer.ToSpaceOfOtherDrawable(rushPlayfield.OverPlayerEffectsContainer.OriginPosition, this);
+                    flashlightPosition.X += RushPlayfield.HIT_TARGET_OFFSET;
+                    FlashlightPosition = flashlightPosition;
+                    flashlightProperties.Validate();
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/Mods/RushModPerfect.cs
+++ b/osu.Game.Rulesets.Rush/Mods/RushModPerfect.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Rush.Mods
+{
+    public class RushModPerfect : ModPerfect
+    {
+    }
+}

--- a/osu.Game.Rulesets.Rush/Mods/RushModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Rush/Mods/RushModSuddenDeath.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Rush.Mods
+{
+    public class RushModSuddenDeath : ModSuddenDeath
+    {
+    }
+}

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -60,13 +60,21 @@ namespace osu.Game.Rulesets.Rush
                 case ModType.DifficultyIncrease:
                     return new Mod[]
                     {
-                        new MultiMod(new RushModDoubleTime(), new RushModNightcore())
+                        new MultiMod(new RushModSuddenDeath(), new RushModPerfect()),
+                        new MultiMod(new RushModDoubleTime(), new RushModNightcore()),
+                        new RushModFlashlight()
                     };
 
                 case ModType.Automation:
                     return new[]
                     {
                         new MultiMod(new RushModAutoplay(), new RushModCinema())
+                    };
+
+                case ModType.Fun:
+                    return new[]
+                    {
+                        new MultiMod(new ModWindUp(), new ModWindDown())
                     };
 
                 default:

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Rush.UI
         public RushPlayerSprite PlayerSprite { get; }
 
         private readonly Container halfPaddingOverEffectContainer;
-        private readonly Container overPlayerEffectsContainer;
+        internal readonly Container OverPlayerEffectsContainer;
 
         private readonly LanePlayfield airLane;
         private readonly LanePlayfield groundLane;
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Rush.UI
                 },
                 new GroundDisplay(),
                 PlayerSprite = new RushPlayerSprite(),
-                overPlayerEffectsContainer = new Container
+                OverPlayerEffectsContainer = new Container
                 {
                     Origin = Anchor.CentreLeft,
                     Anchor = Anchor.CentreLeft,
@@ -181,7 +181,7 @@ namespace osu.Game.Rulesets.Rush.UI
             var pointDifference = rushResult.Judgement.HealthPointIncreaseFor(rushResult);
 
             if (pointDifference != 0)
-                overPlayerEffectsContainer.Add(healthTextPool.Get(h => h.Apply(pointDifference)));
+                OverPlayerEffectsContainer.Add(healthTextPool.Get(h => h.Apply(pointDifference)));
 
             // Display judgement results in a drawable for objects that allow it.
             if (rushJudgedObject.DisplayResult)


### PR DESCRIPTION
This PR adds 5 mods, Flashlight, Perfect, Sudden Death, Wind Up, and Wind Down.

- Flashlight - larger size than other modes (to cover two lanes) and gets smaller when >100 combos and >200 combos.
- Perfect, Sudden Death, Wind Up, and Wind Down has the same effect as other modes.

Flashlight size/location:
![osu_2021-04-24_22-14-25](https://user-images.githubusercontent.com/19150229/115960113-6ffdd080-a54a-11eb-925f-4b12a7f6e2c1.png)

## Videos

Flashlight: https://www.youtube.com/watch?v=X1I1C3IMEPc
Wind Up: https://www.youtube.com/watch?v=oNAT1dYG3g8