### PR TITLE
Simplify the way playfield elements are positioned

### DIFF
--- a/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Rush.UI.Ground
 {
@@ -25,6 +28,7 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
                 {
                     AutoSizeAxes = Axes.X,
                     RelativeSizeAxes = Axes.Y,
+                   // RelativePositionAxes = Axes.X,
                     Direction = FillDirection.Horizontal,
                     Children = new Drawable[]
                     {
@@ -35,19 +39,23 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
             };
         }
 
-        protected override void LoadComplete()
+        [Resolved(canBeNull: true)]
+        private IScrollingInfo scrollingInfo { get; set; }
+
+        private double scrollingRange => scrollingInfo.TimeRange.Value;
+
+        private double? startTime;
+
+        protected override void UpdateAfterChildren()
         {
-            base.LoadComplete();
+            base.UpdateAfterChildren();
 
-            ScheduleAfterChildren(() =>
-            {
-                var pieceWidth = groundFlow.Width / 2;
+            if (!startTime.HasValue)
+                startTime = Time.Current;
 
-                groundFlow.MoveToX(-pieceWidth, pieceWidth / scroll_speed)
-                          .Then()
-                          .MoveToX(0f)
-                          .Loop(1f);
-            });
+            if (scrollingInfo is null) return;
+
+            groundFlow.X = scrollingInfo.Algorithm.PositionAt(0f, Time.Current, scrollingInfo.TimeRange.Value, DrawWidth) % (groundFlow.Width / 2f);
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
@@ -14,8 +14,6 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
     /// </summary>
     public class GroundDisplay : CompositeDrawable
     {
-        private const double scroll_speed = 1f;
-
         private readonly FillFlowContainer groundFlow;
 
         public GroundDisplay()
@@ -23,7 +21,7 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
             Anchor = Anchor.BottomCentre;
             Origin = Anchor.TopCentre;
             RelativeSizeAxes = Axes.Both;
-            Padding = new MarginPadding { Top = 50f, Left = RushPlayfield.HIT_TARGET_OFFSET };
+            Padding = new MarginPadding { Top = 50f };
 
             InternalChildren = new[]
             {
@@ -51,7 +49,7 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
             // Tests don't have scrolling info yet
             if (scrollingInfo is null) return;
 
-            groundFlow.X = scrollingInfo.Algorithm.PositionAt(0f, Time.Current, scrollingInfo.TimeRange.Value, DrawWidth) % (groundFlow.Width / 2f);
+            groundFlow.X = scrollingInfo.Algorithm.PositionAt(0f, Time.Current, scrollingInfo.TimeRange.Value, DrawWidth - RushPlayfield.HIT_TARGET_OFFSET) % (groundFlow.Width / 2f);
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
@@ -31,7 +31,6 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
                 {
                     AutoSizeAxes = Axes.X,
                     RelativeSizeAxes = Axes.Y,
-                   // RelativePositionAxes = Axes.X,
                     Direction = FillDirection.Horizontal,
                     Children = new Drawable[]
                     {
@@ -45,17 +44,11 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
         [Resolved(canBeNull: true)]
         private IScrollingInfo scrollingInfo { get; set; }
 
-        private double scrollingRange => scrollingInfo.TimeRange.Value;
-
-        private double? startTime;
-
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
 
-            if (!startTime.HasValue)
-                startTime = Time.Current;
-
+            // Tests don't have scrolling info yet
             if (scrollingInfo is null) return;
 
             groundFlow.X = scrollingInfo.Algorithm.PositionAt(0f, Time.Current, scrollingInfo.TimeRange.Value, DrawWidth) % (groundFlow.Width / 2f);

--- a/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -14,7 +13,7 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
     /// </summary>
     public class GroundDisplay : CompositeDrawable
     {
-        private readonly FillFlowContainer groundFlow;
+        private readonly CompositeDrawable ground;
 
         public GroundDisplay()
         {
@@ -23,19 +22,9 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
             RelativeSizeAxes = Axes.Both;
             Padding = new MarginPadding { Top = 50f };
 
-            InternalChildren = new[]
+            InternalChildren = new Drawable[]
             {
-                groundFlow = new FillFlowContainer
-                {
-                    AutoSizeAxes = Axes.X,
-                    RelativeSizeAxes = Axes.Y,
-                    Direction = FillDirection.Horizontal,
-                    Children = new Drawable[]
-                    {
-                        new DefaultGround { Name = "Leaving-out piece" },
-                        new DefaultGround { Name = "Coming-in piece" },
-                    }
-                }
+                ground = new DefaultGround(),
             };
         }
 
@@ -49,7 +38,14 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
             // Tests don't have scrolling info yet
             if (scrollingInfo is null) return;
 
-            groundFlow.X = scrollingInfo.Algorithm.PositionAt(0f, Time.Current, scrollingInfo.TimeRange.Value, DrawWidth - RushPlayfield.HIT_TARGET_OFFSET) % (groundFlow.Width / 2f);
+            var groundX = scrollingInfo.Algorithm.PositionAt(0f, Time.Current, scrollingInfo.TimeRange.Value, DrawWidth - RushPlayfield.HIT_TARGET_OFFSET) % (ground.Width / 2f);
+
+
+            // This is to ensure that the ground is still visible before the start of the track
+            if (groundX > 0)
+                groundX = -(ground.Width / 2f) + groundX;
+
+            ground.X = groundX;
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
@@ -20,7 +20,10 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
 
         public GroundDisplay()
         {
+            Anchor = Anchor.BottomCentre;
+            Origin = Anchor.TopCentre;
             RelativeSizeAxes = Axes.Both;
+            Padding = new MarginPadding { Top = 50f, Left = RushPlayfield.HIT_TARGET_OFFSET };
 
             InternalChildren = new[]
             {

--- a/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
@@ -40,7 +40,6 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
 
             var groundX = scrollingInfo.Algorithm.PositionAt(0f, Time.Current, scrollingInfo.TimeRange.Value, DrawWidth - RushPlayfield.HIT_TARGET_OFFSET) % (ground.Width / 2f);
 
-
             // This is to ensure that the ground is still visible before the start of the track
             if (groundX > 0)
                 groundX = -(ground.Width / 2f) + groundX;

--- a/osu.Game.Rulesets.Rush/UI/HealthText.cs
+++ b/osu.Game.Rulesets.Rush/UI/HealthText.cs
@@ -18,8 +18,7 @@ namespace osu.Game.Rulesets.Rush.UI
         public HealthText()
         {
             Origin = Anchor.Centre;
-            RelativePositionAxes = Axes.Both;
-            Position = new Vector2(0.75f, 0.5f);
+            Anchor = Anchor.CentreLeft;
 
             InternalChildren = new Drawable[]
             {

--- a/osu.Game.Rulesets.Rush/UI/RushPlayerSprite.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayerSprite.cs
@@ -134,17 +134,19 @@ namespace osu.Game.Rulesets.Rush.UI
             }
         }
 
-        private readonly float groundY;
-        private readonly float airY;
+        private float groundY => 0;
+        private float airY => -RushPlayfield.DEFAULT_HEIGHT;
 
         private float playHeight => Math.Abs(groundY - airY);
         private float distanceToGround => Math.Abs(Y - groundY);
         private float distanceToAir => Math.Abs(Y - airY);
 
-        public RushPlayerSprite(float groundY, float airY)
+        public RushPlayerSprite()
         {
-            this.groundY = groundY;
-            this.airY = airY;
+            Scale = new Vector2(0.75f);
+            Anchor = Anchor.BottomLeft;
+            Origin = Anchor.BottomLeft;
+            X = RushPlayfield.PLAYER_OFFSET;
 
             AddRangeInternal(Enum.GetValues(typeof(PlayerAnimation)).Cast<PlayerAnimation>().Select(createTextureAnimation));
         }

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -68,7 +68,8 @@ namespace osu.Game.Rulesets.Rush.UI
             RelativeSizeAxes = Axes.X;
             Size = new Vector2(1, DEFAULT_HEIGHT);
             Anchor = Origin = Anchor.Centre;
-            InternalChildren = new Drawable[]{
+            InternalChildren = new Drawable[]
+            {
                 airLane = new LanePlayfield(LanedHitLane.Air),
                 groundLane = new LanePlayfield(LanedHitLane.Ground),
                 // Contains miniboss and duals for now
@@ -92,9 +93,10 @@ namespace osu.Game.Rulesets.Rush.UI
                     Origin = Anchor.CentreLeft,
                     Anchor = Anchor.CentreLeft,
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding{ Left = PLAYER_OFFSET }
+                    Padding = new MarginPadding { Left = PLAYER_OFFSET }
                 },
             };
+
             AddNested(airLane);
             AddNested(groundLane);
             NewResult += onNewResult;

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -65,106 +65,60 @@ namespace osu.Game.Rulesets.Rush.UI
         public RushPlayfield()
         {
             hitPolicy = new RushHitPolicy(this);
-            InternalChildren = new Drawable[]
-            {
-                new GridContainer
-                {
+            RelativeSizeAxes = Axes.X;
+            Size = new Vector2(1, DEFAULT_HEIGHT);
+            Anchor = Origin = Anchor.Centre;
+            InternalChildren = new Drawable[]{
+                new Container{
+                    Name = "Right area",
                     RelativeSizeAxes = Axes.Both,
-                    RowDimensions = new[]
-                    {
-                        new Dimension(GridSizeMode.Distributed), // Top empty area
-                        new Dimension(GridSizeMode.Absolute, DEFAULT_HEIGHT), // Playfield area
-                        new Dimension(GridSizeMode.Distributed), // Ground area, extends to overall height
-                    },
-                    Content = new[]
-                    {
-                        new[]
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
+                    Children = new Drawable[]{
+                        airLane = new LanePlayfield(LanedHitLane.Air),
+                        groundLane = new LanePlayfield(LanedHitLane.Ground),
+                        // Contains miniboss and duals for now
+                        new Container
                         {
-                            Empty()
+                            Name = "Hit Objects",
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
+                            Child = HitObjectContainer
                         },
-                        new Drawable[]
+                        halfPaddingOverEffectContainer = new Container
                         {
-                            new Container
-                            {
-                                Name = "Playfield area",
-                                RelativeSizeAxes = Axes.Both,
-                                Children = new[]
-                                {
-                                    new Container
-                                    {
-                                        Name = "Left area",
-                                        Width = HIT_TARGET_OFFSET,
-                                        RelativeSizeAxes = Axes.Y,
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        Depth = -1,
-                                        Child = new Container
-                                        {
-                                            Name = "Left Play Zone",
-                                            RelativeSizeAxes = Axes.Both,
-                                            Anchor = Anchor.CentreLeft,
-                                            Origin = Anchor.CentreLeft,
-                                            Children = new Drawable[]
-                                            {
-                                                PlayerSprite = new RushPlayerSprite(DEFAULT_HEIGHT, 0)
-                                                {
-                                                    Origin = Anchor.Centre,
-                                                    Position = new Vector2(PLAYER_OFFSET, DEFAULT_HEIGHT),
-                                                    Scale = new Vector2(0.75f),
-                                                },
-                                                overPlayerEffectsContainer = new Container
-                                                {
-                                                    Origin = Anchor.Centre,
-                                                    Anchor = Anchor.Centre,
-                                                    RelativeSizeAxes = Axes.Both,
-                                                }
-                                            }
-                                        },
-                                    },
-                                    new Container
-                                    {
-                                        Name = "Right area",
-                                        RelativeSizeAxes = Axes.Both,
-                                        Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        Children = new Drawable[]
-                                        {
-                                            airLane = new LanePlayfield(LanedHitLane.Air),
-                                            groundLane = new LanePlayfield(LanedHitLane.Ground),
-                                            // Contains miniboss and duals for now
-                                            new Container
-                                            {
-                                                Name = "Hit Objects",
-                                                RelativeSizeAxes = Axes.Both,
-                                                Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
-                                                Child = HitObjectContainer
-                                            },
-                                            halfPaddingOverEffectContainer = new Container
-                                            {
-                                                Name = "Over Effects (Half Padding)",
-                                                RelativeSizeAxes = Axes.Both,
-                                                Padding = new MarginPadding { Left = HIT_TARGET_OFFSET / 2f }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                        },
-                        new Drawable[]
-                        {
-                            new Container
-                            {
-                                Name = "Ground area",
-                                RelativeSizeAxes = Axes.Both,
-                                // Due to the size of the player sprite, we have to push the ground even more to the bottom.
-                                Padding = new MarginPadding { Top = 50f },
-                                Depth = float.MaxValue,
-                                Child = new GroundDisplay(),
-                            }
+                            Name = "Over Effects (Half Padding)",
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Left = HIT_TARGET_OFFSET / 2f }
                         }
                     }
-                }
+                },
+                new Container
+                {
+                    Name = "Ground area",
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.TopCentre,
+                    // Due to the size of the player sprite, we have to push the ground even more to the bottom.
+                    Padding = new MarginPadding { Top = 50f },
+                    Depth = float.MaxValue,
+                    Child = new GroundDisplay(),
+                },
+                PlayerSprite = new RushPlayerSprite(0, -DEFAULT_HEIGHT)
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Position = new Vector2(PLAYER_OFFSET,0),
+                    Scale = new Vector2(0.75f),
+                },
+                overPlayerEffectsContainer = new Container
+                {
+                    Origin = Anchor.CentreLeft,
+                    Anchor = Anchor.CentreLeft,
+                    RelativeSizeAxes = Axes.Both,
+                    Position = new Vector2(PLAYER_OFFSET,0),
+                },
             };
             AddNested(airLane);
             AddNested(groundLane);

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets.Rush.UI
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.TopCentre,
                     // Due to the size of the player sprite, we have to push the ground even more to the bottom.
-                    Padding = new MarginPadding { Top = 50f },
+                    Padding = new MarginPadding { Top = 50f, Left = HIT_TARGET_OFFSET*2 },
                     Depth = float.MaxValue,
                     Child = new GroundDisplay(),
                 },

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Rush.UI
                 {
                     Name = "Over Effects (Half Padding)",
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Left = HIT_TARGET_OFFSET / 4f }
+                    Padding = new MarginPadding { Left = HIT_TARGET_OFFSET * 0.75f }
                 },
                 new GroundDisplay(),
                 PlayerSprite = new RushPlayerSprite(),
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Rush.UI
                     Origin = Anchor.CentreLeft,
                     Anchor = Anchor.CentreLeft,
                     RelativeSizeAxes = Axes.Both,
-                    Position = new Vector2(PLAYER_OFFSET,0),
+                    Padding = new MarginPadding{ Left = PLAYER_OFFSET }
                 },
             };
             AddNested(airLane);

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Rush.UI
     public class RushPlayfield : ScrollingPlayfield, IKeyBindingHandler<RushAction>
     {
         public const float DEFAULT_HEIGHT = 178;
-        public const float HIT_TARGET_OFFSET = 120;
+        public const float HIT_TARGET_OFFSET = 240;
         public const float HIT_TARGET_SIZE = 100;
         public const float PLAYER_OFFSET = 130;
         public const float JUDGEMENT_OFFSET = 100;
@@ -69,49 +69,24 @@ namespace osu.Game.Rulesets.Rush.UI
             Size = new Vector2(1, DEFAULT_HEIGHT);
             Anchor = Origin = Anchor.Centre;
             InternalChildren = new Drawable[]{
-                new Container{
-                    Name = "Right area",
-                    RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft,
-                    Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
-                    Children = new Drawable[]{
-                        airLane = new LanePlayfield(LanedHitLane.Air),
-                        groundLane = new LanePlayfield(LanedHitLane.Ground),
-                        // Contains miniboss and duals for now
-                        new Container
-                        {
-                            Name = "Hit Objects",
-                            RelativeSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
-                            Child = HitObjectContainer
-                        },
-                        halfPaddingOverEffectContainer = new Container
-                        {
-                            Name = "Over Effects (Half Padding)",
-                            RelativeSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Left = HIT_TARGET_OFFSET / 2f }
-                        }
-                    }
-                },
+                airLane = new LanePlayfield(LanedHitLane.Air),
+                groundLane = new LanePlayfield(LanedHitLane.Ground),
+                // Contains miniboss and duals for now
                 new Container
                 {
-                    Name = "Ground area",
+                    Name = "Hit Objects",
                     RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.TopCentre,
-                    // Due to the size of the player sprite, we have to push the ground even more to the bottom.
-                    Padding = new MarginPadding { Top = 50f, Left = HIT_TARGET_OFFSET*2 },
-                    Depth = float.MaxValue,
-                    Child = new GroundDisplay(),
+                    Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
+                    Child = HitObjectContainer
                 },
-                PlayerSprite = new RushPlayerSprite(0, -DEFAULT_HEIGHT)
+                halfPaddingOverEffectContainer = new Container
                 {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    Position = new Vector2(PLAYER_OFFSET,0),
-                    Scale = new Vector2(0.75f),
+                    Name = "Over Effects (Half Padding)",
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Left = HIT_TARGET_OFFSET / 4f }
                 },
+                new GroundDisplay(),
+                PlayerSprite = new RushPlayerSprite(),
                 overPlayerEffectsContainer = new Container
                 {
                     Origin = Anchor.CentreLeft,


### PR DESCRIPTION
Fixes #27 as well.

Currently, a grid is used to specify regions for specific playfield elements to be. However, nearly all elements required further positional adjustments via `anchors`, `origins`, `position`, and `padding`, with some of them having a parent container with even more adjustments. This makes it harder to immediately tell where a playfield element would be, when looking at the properties, since they would be inheriting several layers of properties from parents and grandparents. (It can reach a depth of 5+ containers!)

This PR removes the use of the grid, and reducing the number of parents that can affect positioning of the playfield elements. Most of the positional adjustments are now isolated within the individual playfield elements themselves, rather than being spread out. 


## Differences
* The ground doesn't quite reach the bottom of the screen, stopping right above the progress bar.
* The ground scroll speed now uses the information provided by `IScrollingInfo`, which also fixes the transforms freezing during rewind

## Problems
* ~~The left tile of the ground occasionally spazzes, not sure why. Maybe a problem caused by the ground animation adjustments?~~ **FIXED**