### PR TITLE
Implement automatic fever activation

### DIFF
--- a/osu.Game.Rulesets.Rush/Configuration/FeverActivationMode.cs
+++ b/osu.Game.Rulesets.Rush/Configuration/FeverActivationMode.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Rush.Configuration
+{
+    /// <summary>
+    /// The activation mode of fever for gaining bonus score on hits.
+    /// </summary>
+    public enum FeverActivationMode
+    {
+        /// <summary>
+        /// Automatically once the fever progress fills up.
+        /// </summary>
+        Automatic,
+
+        /// <summary>
+        /// Manually using the <see cref="RushAction.Fever"/> action.
+        /// </summary>
+        Manual,
+    }
+}

--- a/osu.Game.Rulesets.Rush/Configuration/RushRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Rush/Configuration/RushRulesetConfigManager.cs
@@ -17,12 +17,12 @@ namespace osu.Game.Rulesets.Rush.Configuration
         {
             base.InitialiseDefaults();
 
-            SetDefault(RushRulesetSettings.AutomaticFever, true);
+            SetDefault(RushRulesetSettings.FeverActivationMode, FeverActivationMode.Automatic);
         }
     }
 
     public enum RushRulesetSettings
     {
-        AutomaticFever
+        FeverActivationMode
     }
 }

--- a/osu.Game.Rulesets.Rush/Configurations/RushRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Rush/Configurations/RushRulesetConfigManager.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Configuration;
+
+namespace osu.Game.Rulesets.Rush.Configuration
+{
+    public class RushRulesetConfigManager : RulesetConfigManager<RushRulsetSettings>
+    {
+        public RushRulesetConfigManager(SettingsStore settings, RulesetInfo ruleset, int? variant = null)
+            : base(settings, ruleset, variant)
+        {
+        }
+
+        protected override void InitialiseDefaults()
+        {
+            base.InitialiseDefaults();
+
+            SetDefault(RushRulsetSettings.AutomaticFever, true);
+        }
+    }
+
+    public enum RushRulsetSettings
+    {
+        AutomaticFever
+    }
+}

--- a/osu.Game.Rulesets.Rush/Configurations/RushRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Rush/Configurations/RushRulesetConfigManager.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Configuration;
 
 namespace osu.Game.Rulesets.Rush.Configuration
 {
-    public class RushRulesetConfigManager : RulesetConfigManager<RushRulsetSettings>
+    public class RushRulesetConfigManager : RulesetConfigManager<RushRulesetSettings>
     {
         public RushRulesetConfigManager(SettingsStore settings, RulesetInfo ruleset, int? variant = null)
             : base(settings, ruleset, variant)
@@ -17,11 +17,11 @@ namespace osu.Game.Rulesets.Rush.Configuration
         {
             base.InitialiseDefaults();
 
-            SetDefault(RushRulsetSettings.AutomaticFever, true);
+            SetDefault(RushRulesetSettings.AutomaticFever, true);
         }
     }
 
-    public enum RushRulsetSettings
+    public enum RushRulesetSettings
     {
         AutomaticFever
     }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableFeverBonus.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableFeverBonus.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (!Result.HasResult)
                 base.ApplyResult(application);
         }
+
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
         }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableFeverBonus.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableFeverBonus.cs
@@ -26,5 +26,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (!Result.HasResult)
                 base.ApplyResult(application);
         }
+        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        {
+        }
     }
 }

--- a/osu.Game.Rulesets.Rush/Replays/RushAutoGenerator.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushAutoGenerator.cs
@@ -7,6 +7,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Rush.Configuration;
 using osu.Game.Rulesets.Rush.Objects;
 
 namespace osu.Game.Rulesets.Rush.Replays
@@ -83,7 +84,10 @@ namespace osu.Game.Rulesets.Rush.Replays
                     }
                 }
 
-                Replay.Frames.Add(new RushReplayFrame(group.First().Time, actions.ToArray()));
+                Replay.Frames.Add(new RushReplayFrame(group.First().Time, actions.ToArray())
+                {
+                    FeverActivationMode = FeverActivationMode.Automatic,
+                });
             }
 
             return Replay;

--- a/osu.Game.Rulesets.Rush/Replays/RushFramedReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushFramedReplayInputHandler.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Input.StateChanges;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Rush.Configuration;
 
 namespace osu.Game.Rulesets.Rush.Replays
 {
@@ -18,7 +19,10 @@ namespace osu.Game.Rulesets.Rush.Replays
 
         protected override bool IsImportant(RushReplayFrame frame) => frame.Actions.Any();
 
-        public bool UsingAutoFever => CurrentFrame.UsingAutoFever;
+        /// <summary>
+        /// The current fever activation mode determined by the replay's current frame.
+        /// </summary>
+        public FeverActivationMode? FeverActivationMode => CurrentFrame?.FeverActivationMode;
 
         public override void CollectPendingInputs(List<IInput> inputs) =>
             inputs.Add(new ReplayState<RushAction> { PressedActions = CurrentFrame?.Actions ?? new List<RushAction>() });

--- a/osu.Game.Rulesets.Rush/Replays/RushFramedReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushFramedReplayInputHandler.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Rulesets.Rush.Replays
 
         protected override bool IsImportant(RushReplayFrame frame) => frame.Actions.Any();
 
+        public bool UsingAutoFever => CurrentFrame.UsingAutoFever;
+
         public override void CollectPendingInputs(List<IInput> inputs) =>
             inputs.Add(new ReplayState<RushAction> { PressedActions = CurrentFrame?.Actions ?? new List<RushAction>() });
     }

--- a/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Rulesets.Rush.Replays
                 flags >>= 1;
             }
 
+            // We are repurposing ReplayButtonState.Smoke in order to store the AutoFever setting used at the time of recording.
+            // This will serve as an interim solution until non-legacy replays are supported in osu.
             UsingAutoFever = currentFrame.ButtonState.HasFlagFast(ReplayButtonState.Smoke);
         }
 

--- a/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
+++ b/osu.Game.Rulesets.Rush/Replays/RushReplayFrame.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Replays;
@@ -12,22 +13,28 @@ namespace osu.Game.Rulesets.Rush.Replays
 {
     public class RushReplayFrame : ReplayFrame, IConvertibleReplayFrame
     {
+        public bool UsingAutoFever { get; private set; }
+
         public List<RushAction> Actions = new List<RushAction>();
 
         public RushReplayFrame()
         {
         }
 
-        public RushReplayFrame(double time, RushAction? button = null)
+        public RushReplayFrame(double time, RushAction? button = null, bool usingAutoFever = true)
             : base(time)
         {
+            UsingAutoFever = usingAutoFever;
+
             if (button.HasValue)
                 Actions.Add(button.Value);
         }
 
-        public RushReplayFrame(double time, IEnumerable<RushAction> buttons)
+        public RushReplayFrame(double time, IEnumerable<RushAction> buttons, bool usingAutoFever = true)
             : base(time)
         {
+            UsingAutoFever = usingAutoFever;
+
             Actions.AddRange(buttons);
         }
 
@@ -47,6 +54,8 @@ namespace osu.Game.Rulesets.Rush.Replays
                 ++currentBit;
                 flags >>= 1;
             }
+
+            UsingAutoFever = currentFrame.ButtonState.HasFlagFast(ReplayButtonState.Smoke);
         }
 
         public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
@@ -55,7 +64,7 @@ namespace osu.Game.Rulesets.Rush.Replays
             foreach (var action in Actions)
                 flags |= 1u << (int)action;
 
-            return new LegacyReplayFrame(Time, flags, 0f, ReplayButtonState.None);
+            return new LegacyReplayFrame(Time, flags, 0f, UsingAutoFever ? ReplayButtonState.Smoke : ReplayButtonState.None);
         }
     }
 }

--- a/osu.Game.Rulesets.Rush/RushInputManager.cs
+++ b/osu.Game.Rulesets.Rush/RushInputManager.cs
@@ -5,12 +5,15 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using osu.Framework.Input.Bindings;
 using osu.Game.Rulesets.Rush.Objects;
+using osu.Game.Rulesets.Rush.Replays;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Rush
 {
     public class RushInputManager : RulesetInputManager<RushAction>
     {
+        public new RushFramedReplayInputHandler ReplayInputHandler => (RushFramedReplayInputHandler)base.ReplayInputHandler;
+
         /// <summary>
         /// Retrieves all actions in a currenty pressed states.
         /// </summary>

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -8,10 +8,14 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Rush.Beatmaps;
+using osu.Game.Rulesets.Rush.Configuration;
 using osu.Game.Rulesets.Rush.Mods;
 using osu.Game.Rulesets.Rush.Replays;
 using osu.Game.Rulesets.Rush.Scoring;
@@ -35,6 +39,10 @@ namespace osu.Game.Rulesets.Rush
         public override string Description => !IsDevelopmentBuild ? "Rush!" : "Rush! (dev build)";
 
         public override string PlayingVerb => "Punching doods";
+
+        public override RulesetSettingsSubsection CreateSettings() => new RushSettingsSubsection(this);
+
+        public override IRulesetConfigManager CreateConfig(SettingsStore settings) => new RushRulesetConfigManager(settings, RulesetInfo);
 
         public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new DrawableRushRuleset(this, beatmap, mods);
 

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -27,6 +27,12 @@ namespace osu.Game.Rulesets.Rush.UI
     {
         private FeverProcessor feverProcessor;
 
+        protected new RushRulesetConfigManager Config => (RushRulesetConfigManager)base.Config;
+
+        public new RushPlayfield Playfield => (RushPlayfield)base.Playfield;
+
+        public new RushInputManager KeyBindingInputManager => (RushInputManager)base.KeyBindingInputManager;
+
         protected override bool UserScrollSpeedAdjustment => true;
 
         protected override ScrollVisualisationMethod VisualisationMethod => ScrollVisualisationMethod.Constant;
@@ -75,8 +81,6 @@ namespace osu.Game.Rulesets.Rush.UI
         protected override ReplayInputHandler CreateReplayInputHandler(Replay replay) => new RushFramedReplayInputHandler(replay);
 
         protected override ReplayRecorder CreateReplayRecorder(Score score) => new RushReplayRecorder(score);
-
-        public new RushPlayfield Playfield => (RushPlayfield)base.Playfield;
 
         public override DrawableHitObject<RushHitObject> CreateDrawableRepresentation(RushHitObject h) => null;
 

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Rush.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            Config.BindWith(RushRulesetSettings.FeverActivationMode, feverActivationModeSetting);
+            Config?.BindWith(RushRulesetSettings.FeverActivationMode, feverActivationModeSetting);
 
             FrameStableComponents.Add(feverProcessor);
         }

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Rush.UI
 
         protected override void LoadComplete()
         {
-            (Config as RushRulesetConfigManager)?.BindWith(RushRulsetSettings.AutomaticFever, autoFeverSetting);
+            (Config as RushRulesetConfigManager)?.BindWith(RushRulesetSettings.AutomaticFever, autoFeverSetting);
         }
 
         // Auto fever related stuff

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Rulesets.Rush.UI
 
         public new RushInputManager KeyBindingInputManager => (RushInputManager)base.KeyBindingInputManager;
 
+        public FeverActivationMode FeverActivationMode => KeyBindingInputManager.ReplayInputHandler?.FeverActivationMode ?? feverActivationModeSetting.Value;
+
         protected override bool UserScrollSpeedAdjustment => true;
 
         protected override ScrollVisualisationMethod VisualisationMethod => ScrollVisualisationMethod.Constant;
@@ -56,23 +58,15 @@ namespace osu.Game.Rulesets.Rush.UI
             return dependencies;
         }
 
+        private readonly Bindable<FeverActivationMode> feverActivationModeSetting = new Bindable<FeverActivationMode>();
+
         [BackgroundDependencyLoader]
         private void load()
         {
+            Config.BindWith(RushRulesetSettings.FeverActivationMode, feverActivationModeSetting);
+
             FrameStableComponents.Add(feverProcessor);
         }
-
-        protected override void LoadComplete()
-        {
-            (Config as RushRulesetConfigManager)?.BindWith(RushRulesetSettings.AutomaticFever, autoFeverSetting);
-        }
-
-        // Auto fever related stuff
-        private readonly Bindable<bool> autoFeverSetting = new Bindable<bool>(true);
-
-        private RushFramedReplayInputHandler replayInputHandler => ((RushInputManager)KeyBindingInputManager).ReplayInputHandler as RushFramedReplayInputHandler;
-
-        public bool UsingAutoFever => replayInputHandler?.UsingAutoFever ?? autoFeverSetting.Value;
 
         public bool PlayerCollidesWith(HitObject hitObject) => Playfield.PlayerSprite.CollidesWith(hitObject);
 

--- a/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/UI/DrawableRushRuleset.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Input;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -11,6 +12,7 @@ using osu.Game.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Rush.Configuration;
 using osu.Game.Rulesets.Rush.Objects;
 using osu.Game.Rulesets.Rush.Replays;
 using osu.Game.Rulesets.Rush.UI.Fever;
@@ -53,6 +55,18 @@ namespace osu.Game.Rulesets.Rush.UI
         {
             FrameStableComponents.Add(feverProcessor);
         }
+
+        protected override void LoadComplete()
+        {
+            (Config as RushRulesetConfigManager)?.BindWith(RushRulsetSettings.AutomaticFever, autoFeverSetting);
+        }
+
+        // Auto fever related stuff
+        private readonly Bindable<bool> autoFeverSetting = new Bindable<bool>(true);
+
+        private RushFramedReplayInputHandler replayInputHandler => ((RushInputManager)KeyBindingInputManager).ReplayInputHandler as RushFramedReplayInputHandler;
+
+        public bool UsingAutoFever => replayInputHandler?.UsingAutoFever ?? autoFeverSetting.Value;
 
         public bool PlayerCollidesWith(HitObject hitObject) => Playfield.PlayerSprite.CollidesWith(hitObject);
 

--- a/osu.Game.Rulesets.Rush/UI/Fever/FeverProcessor.cs
+++ b/osu.Game.Rulesets.Rush/UI/Fever/FeverProcessor.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Rush.UI.Fever
         [Resolved(canBeNull: true)]
         private DrawableRushRuleset drawableRuleset { get; set; }
 
-        private bool usingAutoFever => drawableRuleset?.UsingAutoFever ?? true;
+        private FeverActivationMode feverActivationMode => drawableRuleset?.FeverActivationMode ?? default;
 
         protected override void Update()
         {
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Rush.UI.Fever
             if (!InFeverMode.Value)
                 FeverProgress.Value += feverIncreaseFor(result);
 
-            if (usingAutoFever && FeverProgress.Value >= 1)
+            if (feverActivationMode == FeverActivationMode.Automatic && FeverProgress.Value >= 1)
                 TryActivateFever();
         }
 

--- a/osu.Game.Rulesets.Rush/UI/Fever/FeverProcessor.cs
+++ b/osu.Game.Rulesets.Rush/UI/Fever/FeverProcessor.cs
@@ -39,13 +39,10 @@ namespace osu.Game.Rulesets.Rush.UI.Fever
             MaxValue = 1.0f,
         };
 
-        private readonly Bindable<bool> autoFever = new Bindable<bool>(true);
+        [Resolved(canBeNull: true)]
+        private DrawableRushRuleset drawableRuleset { get; set; }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(RushRulesetConfigManager rushConfigs)
-        {
-            rushConfigs?.BindWith(RushRulsetSettings.AutomaticFever, autoFever);
-        }
+        private bool usingAutoFever => drawableRuleset?.UsingAutoFever ?? true;
 
         protected override void Update()
         {
@@ -105,7 +102,7 @@ namespace osu.Game.Rulesets.Rush.UI.Fever
             if (!InFeverMode.Value)
                 FeverProgress.Value += feverIncreaseFor(result);
 
-            if (autoFever.Value && FeverProgress.Value >= 1)
+            if (usingAutoFever && FeverProgress.Value >= 1)
                 TryActivateFever();
         }
 

--- a/osu.Game.Rulesets.Rush/UI/Fever/FeverProcessor.cs
+++ b/osu.Game.Rulesets.Rush/UI/Fever/FeverProcessor.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Statistics;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Rush.Configuration;
 using osu.Game.Rulesets.Rush.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Utils;
@@ -36,6 +38,14 @@ namespace osu.Game.Rulesets.Rush.UI.Fever
             MinValue = 0.0f,
             MaxValue = 1.0f,
         };
+
+        private readonly Bindable<bool> autoFever = new Bindable<bool>(true);
+
+        [BackgroundDependencyLoader(true)]
+        private void load(RushRulesetConfigManager rushConfigs)
+        {
+            rushConfigs?.BindWith(RushRulsetSettings.AutomaticFever, autoFever);
+        }
 
         protected override void Update()
         {
@@ -94,6 +104,9 @@ namespace osu.Game.Rulesets.Rush.UI.Fever
 
             if (!InFeverMode.Value)
                 FeverProgress.Value += feverIncreaseFor(result);
+
+            if (autoFever.Value && FeverProgress.Value >= 1)
+                TryActivateFever();
         }
 
         protected override void RevertResultInternal(JudgementResult result)

--- a/osu.Game.Rulesets.Rush/UI/RushReplayRecorder.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushReplayRecorder.cs
@@ -3,9 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Game.Rulesets.Replays;
-using osu.Game.Rulesets.Rush.Configuration;
 using osu.Game.Rulesets.Rush.Replays;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
@@ -15,20 +13,22 @@ namespace osu.Game.Rulesets.Rush.UI
 {
     public class RushReplayRecorder : ReplayRecorder<RushAction>
     {
-        private readonly Bindable<bool> automaticFever = new Bindable<bool>(true);
+        [Resolved(canBeNull: true)]
+        private DrawableRushRuleset drawableRuleset { get; set; }
 
         public RushReplayRecorder(Score target)
             : base(target)
         {
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(RushRulesetConfigManager rushConfigs)
-        {
-            rushConfigs?.BindWith(RushRulesetSettings.AutomaticFever, automaticFever);
-        }
-
         protected override ReplayFrame HandleFrame(Vector2 mousePosition, List<RushAction> actions, ReplayFrame previousFrame)
-            => new RushReplayFrame(Time.Current, actions, automaticFever.Value);
+        {
+            var frame = new RushReplayFrame(Time.Current, actions);
+
+            if (drawableRuleset != null)
+                frame.FeverActivationMode = drawableRuleset.FeverActivationMode;
+
+            return frame;
+        }
     }
 }

--- a/osu.Game.Rulesets.Rush/UI/RushReplayRecorder.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushReplayRecorder.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Rush.UI
         [BackgroundDependencyLoader(true)]
         private void load(RushRulesetConfigManager rushConfigs)
         {
-            rushConfigs?.BindWith(RushRulsetSettings.AutomaticFever, automaticFever);
+            rushConfigs?.BindWith(RushRulesetSettings.AutomaticFever, automaticFever);
         }
 
         protected override ReplayFrame HandleFrame(Vector2 mousePosition, List<RushAction> actions, ReplayFrame previousFrame)

--- a/osu.Game.Rulesets.Rush/UI/RushReplayRecorder.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushReplayRecorder.cs
@@ -2,7 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Rush.Configuration;
 using osu.Game.Rulesets.Rush.Replays;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
@@ -12,12 +15,20 @@ namespace osu.Game.Rulesets.Rush.UI
 {
     public class RushReplayRecorder : ReplayRecorder<RushAction>
     {
+        private readonly Bindable<bool> automaticFever = new Bindable<bool>(true);
+
         public RushReplayRecorder(Score target)
             : base(target)
         {
         }
 
+        [BackgroundDependencyLoader(true)]
+        private void load(RushRulesetConfigManager rushConfigs)
+        {
+            rushConfigs?.BindWith(RushRulsetSettings.AutomaticFever, automaticFever);
+        }
+
         protected override ReplayFrame HandleFrame(Vector2 mousePosition, List<RushAction> actions, ReplayFrame previousFrame)
-            => new RushReplayFrame(Time.Current, actions);
+            => new RushReplayFrame(Time.Current, actions, automaticFever.Value);
     }
 }

--- a/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
@@ -22,10 +22,6 @@ namespace osu.Game.Rulesets.Rush.UI
         {
             var config = (RushRulesetConfigManager)Config;
 
-            // for an odd reason, Config seems to be passed as null when creating it. doesnt even get called...
-            if (config == null)
-                return;
-
             Children = new Drawable[]
             {
                 new SettingsCheckbox

--- a/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Rush.UI
                 new SettingsCheckbox
                 {
                     LabelText = "Automatic Fever activation",
-                    Current = config.GetBindable<bool>(RushRulsetSettings.AutomaticFever)
+                    Current = config.GetBindable<bool>(RushRulesetSettings.AutomaticFever)
                 },
             };
         }

--- a/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
@@ -10,11 +10,14 @@ namespace osu.Game.Rulesets.Rush.UI
 {
     public class RushSettingsSubsection : RulesetSettingsSubsection
     {
-        protected override string Header => RushRuleset.IsDevelopmentBuild ? "rush (Dev build)" : "rush";
+        private readonly Ruleset ruleset;
+
+        protected override string Header => ruleset.Description;
 
         public RushSettingsSubsection(Ruleset ruleset)
             : base(ruleset)
         {
+            this.ruleset = ruleset;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
@@ -12,6 +12,8 @@ namespace osu.Game.Rulesets.Rush.UI
     {
         private readonly Ruleset ruleset;
 
+        protected new RushRulesetConfigManager Config => (RushRulesetConfigManager)base.Config;
+
         protected override string Header => ruleset.Description;
 
         public RushSettingsSubsection(Ruleset ruleset)
@@ -23,14 +25,12 @@ namespace osu.Game.Rulesets.Rush.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            var config = (RushRulesetConfigManager)Config;
-
             Children = new Drawable[]
             {
-                new SettingsCheckbox
+                new SettingsEnumDropdown<FeverActivationMode>
                 {
-                    LabelText = "Automatic Fever activation",
-                    Current = config.GetBindable<bool>(RushRulesetSettings.AutomaticFever)
+                    LabelText = "Fever activation mode",
+                    Current = Config.GetBindable<FeverActivationMode>(RushRulesetSettings.FeverActivationMode)
                 },
             };
         }

--- a/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushSettingsSubsection.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Rush.Configuration;
+
+namespace osu.Game.Rulesets.Rush.UI
+{
+    public class RushSettingsSubsection : RulesetSettingsSubsection
+    {
+        protected override string Header => RushRuleset.IsDevelopmentBuild ? "rush (Dev build)" : "rush";
+
+        public RushSettingsSubsection(Ruleset ruleset)
+            : base(ruleset)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var config = (RushRulesetConfigManager)Config;
+
+            // for an odd reason, Config seems to be passed as null when creating it. doesnt even get called...
+            if (config == null)
+                return;
+
+            Children = new Drawable[]
+            {
+                new SettingsCheckbox
+                {
+                    LabelText = "Automatic Fever activation",
+                    Current = config.GetBindable<bool>(RushRulsetSettings.AutomaticFever)
+                },
+            };
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces an option to enable automatic fever activation, which is on by default.

When it is on, fever will be activated when a result causes the progress to fill to 100%, using the `TryActivateFever` method.

`ReplayButtonState.Smoke` has been repurposed to store the auto fever setting, and is used to ensure that replays will use the settings set at the time of recording, so as to prevent desyncs. The `UsingAutoFever` state provided by `RushFramedInputHandler` will always take priority if a replay is active.

`FeverProcessor` uses `DrawableRushRuleset.UsingAutoFever` in order to determine whether it should automatically trigger fever, and has no knowledge of whether a replay is active or not. (`DrawableRushRulset.UsingAutoFever` already prioritizes replays)