### PR TITLE
Optimize DefaultGround

### DIFF
--- a/osu.Game.Rulesets.Rush/UI/Ground/DefaultGround.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/DefaultGround.cs
@@ -112,7 +112,8 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
             if (invalidation.HasFlagFast(Invalidation.DrawSize))
             {
                 slats.Clear(false);
-                for (float i = 0; i < DrawWidth; i += slats_spacing)
+
+                for (float i = 0; i < DrawWidth + slats_spacing; i += slats_spacing)
                     slats.Add(linePool.Get(l => l.X = i));
             }
 

--- a/osu.Game.Rulesets.Rush/UI/Ground/DefaultGround.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/DefaultGround.cs
@@ -33,7 +33,6 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
 
         private readonly DrawablePool<GroundLine> linePool;
 
-
         public DefaultGround()
         {
             RelativeSizeAxes = Axes.Both;

--- a/osu.Game.Rulesets.Rush/UI/Ground/DefaultGround.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/DefaultGround.cs
@@ -1,11 +1,16 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Layout;
+using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 using osuTK.Graphics;
 
@@ -17,26 +22,29 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
 
         private static readonly ColourInfo slat_colour = ColourInfo.GradientVertical(Color4.Gray.Opacity(0.8f), Color4.Gray.Opacity(0.4f));
         private static readonly Vector2 slat_size = new Vector2(10f, 100f);
+
         private const float slat_angle = -40f;
 
         private const float slats_spacing = 100f;
 
         private static readonly Color4 ground_colour = Color4.Gray.Opacity(0.2f);
 
-        private readonly FillFlowContainer slatsFlow;
+        private readonly Container slats;
+
+        private readonly DrawablePool<GroundLine> linePool;
+
 
         public DefaultGround()
         {
-            AutoSizeAxes = Axes.X;
-            RelativeSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.Both;
 
             InternalChild = new FillFlowContainer
             {
-                AutoSizeAxes = Axes.X,
-                RelativeSizeAxes = Axes.Y,
+                RelativeSizeAxes = Axes.Both,
                 Direction = FillDirection.Vertical,
                 Children = new Drawable[]
                 {
+                    linePool = new DrawablePool<GroundLine>(10),
                     new Box
                     {
                         Name = "Top line",
@@ -49,7 +57,8 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
                     {
                         Name = "Platform",
                         Masking = true,
-                        AutoSizeAxes = Axes.Both,
+                        AutoSizeAxes = Axes.Y,
+                        RelativeSizeAxes = Axes.X,
                         Children = new Drawable[]
                         {
                             new Box
@@ -57,7 +66,7 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
                                 RelativeSizeAxes = Axes.Both,
                                 Colour = platform_colour,
                             },
-                            slatsFlow = new FillFlowContainer
+                            slats = new Container
                             {
                                 AutoSizeAxes = Axes.Both,
                             },
@@ -80,23 +89,53 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
             };
         }
 
-        protected override void LoadComplete()
+        [Resolved(canBeNull: true)]
+        private IScrollingInfo scrollingInfo { get; set; }
+
+        protected override void UpdateAfterChildren()
         {
-            base.LoadComplete();
+            base.UpdateAfterChildren();
 
-            // FIXME: this is hacky but serves its purpose with no impact.
-            // should add required slats on size invalidations from parent.
-            const int maximum_slat_count = 125;
+            // Tests don't have scrolling info yet
+            if (scrollingInfo is null) return;
 
-            for (int i = 0; i < maximum_slat_count; i++)
+            var groundX = scrollingInfo.Algorithm.PositionAt(0f, Time.Current, scrollingInfo.TimeRange.Value, DrawWidth - RushPlayfield.HIT_TARGET_OFFSET) % slats_spacing;
+
+            // This is to ensure that the ground is still visible before the start of the track
+            if (groundX > 0)
+                groundX = -slats_spacing + groundX;
+
+            slats.X = groundX;
+        }
+
+        protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
+        {
+            if (invalidation.HasFlagFast(Invalidation.DrawSize))
             {
-                slatsFlow.Add(new Box
+                slats.Clear(false);
+                for (float i = 0; i < DrawWidth; i += slats_spacing)
+                    slats.Add(linePool.Get(l => l.X = i));
+            }
+
+            return base.OnInvalidate(invalidation, source);
+        }
+
+        private class GroundLine : PoolableDrawable
+        {
+            public override bool RemoveWhenNotAlive => false;
+
+            public GroundLine()
+            {
+                Colour = slat_colour;
+                Anchor = Anchor.TopLeft;
+                Origin = Anchor.TopLeft;
+                Size = slat_size;
+                Rotation = slat_angle;
+                Margin = new MarginPadding { Bottom = -10f };
+                InternalChild = new Box
                 {
-                    Colour = slat_colour,
-                    Size = slat_size,
-                    Rotation = slat_angle,
-                    Margin = new MarginPadding { Right = slats_spacing, Bottom = -10f },
-                });
+                    RelativeSizeAxes = Axes.Both
+                };
             }
         }
     }

--- a/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
@@ -27,24 +27,5 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
                 ground = new DefaultGround(),
             };
         }
-
-        [Resolved(canBeNull: true)]
-        private IScrollingInfo scrollingInfo { get; set; }
-
-        protected override void UpdateAfterChildren()
-        {
-            base.UpdateAfterChildren();
-
-            // Tests don't have scrolling info yet
-            if (scrollingInfo is null) return;
-
-            var groundX = scrollingInfo.Algorithm.PositionAt(0f, Time.Current, scrollingInfo.TimeRange.Value, DrawWidth - RushPlayfield.HIT_TARGET_OFFSET) % (ground.Width / 2f);
-
-            // This is to ensure that the ground is still visible before the start of the track
-            if (groundX > 0)
-                groundX = -(ground.Width / 2f) + groundX;
-
-            ground.X = groundX;
-        }
     }
 }

--- a/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Rush.UI.Ground
 {
@@ -13,8 +11,6 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
     /// </summary>
     public class GroundDisplay : CompositeDrawable
     {
-        private readonly CompositeDrawable ground;
-
         public GroundDisplay()
         {
             Anchor = Anchor.BottomCentre;
@@ -24,7 +20,7 @@ namespace osu.Game.Rulesets.Rush.UI.Ground
 
             InternalChildren = new Drawable[]
             {
-                ground = new DefaultGround(),
+                new DefaultGround(),
             };
         }
     }


### PR DESCRIPTION
Previously, `DefaultGround` loaded a tonne of lines for the platform, this is to ensure that the ground is long enough that it will not cut off on wider monitors. However, having a whole bunch of lines added to the FillFlowContainer is very wasteful, when most of it is never seen.

This PR makes it so that the slats are added/removed based on draw size invalidations, and no more is added than the bare minimum required to cover the width of the playfield.

This also fixes the random jitter that occurs every now and then, since we are using the exact slat spacing for the illusion rather than using `ground.DrawSize.X/2` as an approximation.