### PR TITLE
Remove unique dev assembly

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -17,11 +17,11 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Development --no-restore
+      run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
         name: Rush (dev build)
-        path: osu.Game.Rulesets.Rush/bin/Development/netstandard2.1/osu.Game.Rulesets.Rush-dev.dll
+        path: osu.Game.Rulesets.Rush/bin/Debug/netstandard2.1/osu.Game.Rulesets.Rush.dll

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,17 +25,5 @@
             "preLaunchTask": "Build tests (Release)",
             "console": "internalConsole"
         },
-        {
-            "name": "Rush for osu! (Tests, Development)",
-            "type": "coreclr",
-            "request": "launch",
-            "program": "dotnet",
-            "args": [
-                "${workspaceRoot}/osu.Game.Rulesets.Rush.Tests/bin/Development/net5.0/osu.Game.Rulesets.Rush.Tests.dll"
-            ],
-            "cwd": "${workspaceRoot}",
-            "preLaunchTask": "Build tests (Development)",
-            "console": "internalConsole"
-        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,21 +30,6 @@
             "group": "build",
             "problemMatcher": "$msCompile"
         },
-        {
-            "label": "Build tests (Development)",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "build",
-                "osu.Game.Rulesets.Rush.Tests",
-                "/p:Configuration=Development",
-                "/p:GenerateFullPaths=true",
-                "/m",
-                "/verbosity:m"
-            ],
-            "group": "build",
-            "problemMatcher": "$msCompile"
-        },
         // Test Tasks
         {
             "label": "Run tests (Debug)",

--- a/osu.Game.Rulesets.Rush.sln
+++ b/osu.Game.Rulesets.Rush.sln
@@ -11,21 +11,16 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		Development|Any CPU = Development|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Development|Any CPU.ActiveCfg = Development|Any CPU
-		{5AE1F0F1-DAFA-46E7-959C-DA233B7C87E9}.Development|Any CPU.Build.0 = Development|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Development|Any CPU.ActiveCfg = Development|Any CPU
-		{B4577C85-CB83-462A-BCE3-22FFEB16311D}.Development|Any CPU.Build.0 = Development|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -28,13 +30,12 @@ namespace osu.Game.Rulesets.Rush
 {
     public class RushRuleset : Ruleset
     {
-        public const string SHORT_NAME = "rush";
-
-        private static readonly Lazy<bool> is_development_build = new Lazy<bool>(() => typeof(RushRuleset).Assembly.GetName().Name.EndsWith("-dev"));
+        private static readonly Lazy<bool> is_development_build
+            = new Lazy<bool>(() => typeof(RushRuleset).Assembly.GetCustomAttributes(false).OfType<DebuggableAttribute>().Any(da => da.IsJITTrackingEnabled));
 
         public static bool IsDevelopmentBuild => is_development_build.Value;
 
-        public override string ShortName => !IsDevelopmentBuild ? SHORT_NAME : $"{SHORT_NAME}-dev";
+        public override string ShortName => "rush";
 
         public override string Description => !IsDevelopmentBuild ? "Rush!" : "Rush! (dev build)";
 

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -30,12 +30,14 @@ namespace osu.Game.Rulesets.Rush
 {
     public class RushRuleset : Ruleset
     {
+        public const string SHORT_NAME = "rush";
+
         private static readonly Lazy<bool> is_development_build
             = new Lazy<bool>(() => typeof(RushRuleset).Assembly.GetCustomAttributes(false).OfType<DebuggableAttribute>().Any(da => da.IsJITTrackingEnabled));
 
         public static bool IsDevelopmentBuild => is_development_build.Value;
 
-        public override string ShortName => "rush";
+        public override string ShortName => SHORT_NAME;
 
         public override string Description => !IsDevelopmentBuild ? "Rush!" : "Rush! (dev build)";
 

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -1,38 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Label="Project">
-    <Configurations>Debug;Release;Development</Configurations>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <OutputType>Library</OutputType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <RootNamespace>osu.Game.Rulesets.Rush</RootNamespace>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Development' ">
-    <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
-  </PropertyGroup>
-  <Choose>
-    <When Condition=" '$(Configuration)' == 'Release' ">
-      <PropertyGroup>
-        <AssemblyName>osu.Game.Rulesets.Rush</AssemblyName>
+    <PropertyGroup Label="Project">
         <AssemblyTitle>rush for osu!</AssemblyTitle>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <AssemblyName>osu.Game.Rulesets.Rush-dev</AssemblyName>
+        <AssemblyName>osu.Game.Rulesets.Rush</AssemblyName>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <OutputType>Library</OutputType>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <RootNamespace>osu.Game.Rulesets.Rush</RootNamespace>
+    </PropertyGroup>
+    <PropertyGroup Condition="!('$(Configuration)' == 'Release')">
         <AssemblyTitle>rush for osu! (development build)</AssemblyTitle>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <ItemGroup>
-    <!-- The automated version of this (<EmbeddedResource Include="xyz\**" />) would prepend the RootNamespace to name,
-         that will not work well with DllResourceStore as it can only determine the root namespace via AssemblyName,
-         and we change that based on the build configuration for separation purposes.
-         Therefore prepend the AssemblyName to embedded resources names instead. -->
-    <EmbeddedResource Include="Resources\**">
-      <LogicalName>$(AssemblyName).$([System.String]::Copy(%(Identity)).Replace($([System.IO.Path]::DirectorySeparatorChar.ToString()), '.'))</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2021.927.0" />
-  </ItemGroup>
+    </PropertyGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Resources\**"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="ppy.osu.Game" Version="2021.927.0" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
While it was nice and convenient to run the release and dev builds side by side in osu, it was causing problems elsewhere, such as shortname problems, and debug and incompatibilities with dynamic compilation (multiple assemblies with same object). It was essentially trading one convenience for the loss of others.

This shouldn't affect end-users much, as ideally, they'd only run release builds. 
<sub>Big RIP for those who intentionally download dev builds just to fill the ruleset bar</sub> 

Build artifacts will instead use the Debug builds.