### PR TITLE
Implement visibility reduction mods

### DIFF
--- a/osu.Game.Rulesets.Rush/Mods/RushModFadeIn.cs
+++ b/osu.Game.Rulesets.Rush/Mods/RushModFadeIn.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Rush.UI;
+
+namespace osu.Game.Rulesets.Rush.Mods
+{
+    public class RushModFadeIn : RushModPlayfieldCover
+    {
+        public override string Name => "Fade In";
+        public override string Acronym => "FI";
+
+        public override string Description => @"Keys fade in before you hit them!";
+        public override double ScoreMultiplier => 1;
+
+        protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AlongScroll;
+    }
+}

--- a/osu.Game.Rulesets.Rush/Mods/RushModHidden.cs
+++ b/osu.Game.Rulesets.Rush/Mods/RushModHidden.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Rush.UI;
+
+namespace osu.Game.Rulesets.Rush.Mods
+{
+    public class RushModHidden : RushModPlayfieldCover
+    {
+        public override string Description => @"Keys fade out before you hit them!";
+        public override double ScoreMultiplier => 1;
+
+        protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;
+    }
+}

--- a/osu.Game.Rulesets.Rush/Mods/RushModPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Rush/Mods/RushModPlayfieldCover.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Mods;
@@ -24,18 +25,28 @@ namespace osu.Game.Rulesets.Rush.Mods
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<RushHitObject> drawableRuleset)
         {
             RushPlayfield rushPlayfield = (RushPlayfield)drawableRuleset.Playfield;
-            Container hitObjectArea = rushPlayfield.HitObjectArea;
-            Container hitObjectAreaParent = (Container)rushPlayfield.HitObjectArea.Parent;
-            hitObjectAreaParent.Remove(hitObjectArea);
 
-            PlayfieldCoveringWrapper wrapper = new PlayfieldCoveringWrapper(hitObjectArea)
-            {
-                RelativeSizeAxes = Axes.Both,
-                Direction = ExpandDirection,
-                Coverage = 0.5f,
+            List<Container> hitObjectAreas = new List<Container>{
+                (Container)rushPlayfield.AirLane.HitObjectContainer.Parent,
+                (Container)rushPlayfield.GroundLane.HitObjectContainer.Parent,
+                (Container)rushPlayfield.HitObjectContainer.Parent,
             };
 
-            hitObjectAreaParent.Add(wrapper);
+
+            foreach (var area in hitObjectAreas)
+            {
+                Container hitObjectAreaParent = (Container)area.Parent;
+                hitObjectAreaParent.Remove(area);
+
+                PlayfieldCoveringWrapper wrapper = new PlayfieldCoveringWrapper(area)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = ExpandDirection,
+                    Coverage = 0.5f,
+                };
+
+                hitObjectAreaParent.Add(wrapper);
+            }
         }
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)

--- a/osu.Game.Rulesets.Rush/Mods/RushModPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Rush/Mods/RushModPlayfieldCover.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Rush.Objects;
+using osu.Game.Rulesets.Rush.UI;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.Rush.Mods
+{
+    public abstract class RushModPlayfieldCover : ModHidden, IApplicableToDrawableRuleset<RushHitObject>
+    {
+        public override Type[] IncompatibleMods => new[] { typeof(ModFlashlight<RushHitObject>) };
+
+        /// <summary>
+        /// The direction in which the cover should expand.
+        /// </summary>
+        protected abstract CoverExpandDirection ExpandDirection { get; }
+
+        public virtual void ApplyToDrawableRuleset(DrawableRuleset<RushHitObject> drawableRuleset)
+        {
+            RushPlayfield rushPlayfield = (RushPlayfield)drawableRuleset.Playfield;
+            Container hitObjectArea = rushPlayfield.HitObjectArea;
+            Container hitObjectAreaParent = (Container)rushPlayfield.HitObjectArea.Parent;
+            hitObjectAreaParent.Remove(hitObjectArea);
+
+            PlayfieldCoveringWrapper wrapper = new PlayfieldCoveringWrapper(hitObjectArea)
+            {
+                RelativeSizeAxes = Axes.Both,
+                Direction = ExpandDirection,
+                Coverage = 0.5f,
+            };
+
+            hitObjectAreaParent.Add(wrapper);
+        }
+
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        {
+        }
+
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -70,6 +70,7 @@ namespace osu.Game.Rulesets.Rush
                     {
                         new MultiMod(new RushModSuddenDeath(), new RushModPerfect()),
                         new MultiMod(new RushModDoubleTime(), new RushModNightcore()),
+                        new RushModHidden(),
                         new RushModFlashlight()
                     };
 

--- a/osu.Game.Rulesets.Rush/RushRuleset.cs
+++ b/osu.Game.Rulesets.Rush/RushRuleset.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Rush
                     {
                         new MultiMod(new RushModSuddenDeath(), new RushModPerfect()),
                         new MultiMod(new RushModDoubleTime(), new RushModNightcore()),
-                        new RushModHidden(),
+                        new MultiMod(new RushModHidden(), new RushModFadeIn()),
                         new RushModFlashlight()
                     };
 

--- a/osu.Game.Rulesets.Rush/UI/LanePlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/LanePlayfield.cs
@@ -30,9 +30,10 @@ namespace osu.Game.Rulesets.Rush.UI
 
             Name = $"{(isAirLane ? "Air" : "Ground")} Playfield";
             Padding = new MarginPadding { Left = RushPlayfield.HIT_TARGET_OFFSET };
-            Anchor = Origin = isAirLane ? Anchor.TopCentre : Anchor.BottomCentre;
+            Anchor = isAirLane ? Anchor.TopLeft : Anchor.BottomLeft;
+            Origin = Anchor.CentreLeft;
             RelativeSizeAxes = Axes.Both;
-            Size = new Vector2(1, 0);
+            Size = new Vector2(1, 0.5f);
 
             AddRangeInternal(new Drawable[]
             {
@@ -47,10 +48,30 @@ namespace osu.Game.Rulesets.Rush.UI
                         RelativeSizeAxes = Axes.Both,
                     }, confineMode: ConfineMode.ScaleToFit),
                 },
-                effectsContainer = new Container(),
-                judgementContainer = new JudgementContainer<DrawableJudgement>(),
-                HitObjectContainer,
-            });
+                effectsContainer = new Container()
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft
+                },
+                judgementContainer = new JudgementContainer<DrawableJudgement>()
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft
+                },
+                new Container{
+                    Padding = new MarginPadding { Left = -RushPlayfield.HIT_TARGET_OFFSET },
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new Container{
+                        Padding = new MarginPadding { Left = +RushPlayfield.HIT_TARGET_OFFSET },
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        RelativeSizeAxes = Axes.Both,
+                        Child = HitObjectContainer,
+                    }
+                }
+    });
         }
 
         [Resolved]

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -42,6 +42,8 @@ namespace osu.Game.Rulesets.Rush.UI
         private readonly LanePlayfield airLane;
         private readonly LanePlayfield groundLane;
 
+        public readonly Container HitObjectArea;
+
         public IEnumerable<DrawableHitObject> AllAliveHitObjects
         {
             get
@@ -77,15 +79,26 @@ namespace osu.Game.Rulesets.Rush.UI
             Anchor = Origin = Anchor.Centre;
             InternalChildren = new Drawable[]
             {
-                airLane = new LanePlayfield(LanedHitLane.Air),
-                groundLane = new LanePlayfield(LanedHitLane.Ground),
-                // Contains miniboss and duals for now
                 new Container
                 {
-                    Name = "Hit Objects",
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
-                    Child = HitObjectContainer
+                    Child = HitObjectArea = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Children = new Drawable[]
+                        {
+                            airLane = new LanePlayfield(LanedHitLane.Air),
+                            groundLane = new LanePlayfield(LanedHitLane.Ground),
+                            // Contains miniboss and duals for now
+                            new Container
+                            {
+                                Name = "Hit Objects",
+                                RelativeSizeAxes = Axes.Both,
+                                Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
+                                Child = HitObjectContainer
+                            },
+                        }
+                    }
                 },
                 halfPaddingOverEffectContainer = new Container
                 {

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -39,10 +39,8 @@ namespace osu.Game.Rulesets.Rush.UI
         private readonly Container halfPaddingOverEffectContainer;
         internal readonly Container OverPlayerEffectsContainer;
 
-        private readonly LanePlayfield airLane;
-        private readonly LanePlayfield groundLane;
-
-        public readonly Container HitObjectArea;
+        public readonly LanePlayfield AirLane;
+        public readonly LanePlayfield GroundLane;
 
         public IEnumerable<DrawableHitObject> AllAliveHitObjects
         {
@@ -82,20 +80,25 @@ namespace osu.Game.Rulesets.Rush.UI
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = HitObjectArea = new Container
+                    Child = new Container
                     {
                         RelativeSizeAxes = Axes.Both,
                         Children = new Drawable[]
                         {
-                            airLane = new LanePlayfield(LanedHitLane.Air),
-                            groundLane = new LanePlayfield(LanedHitLane.Ground),
+                            AirLane = new LanePlayfield(LanedHitLane.Air),
+                            GroundLane = new LanePlayfield(LanedHitLane.Ground),
                             // Contains miniboss and duals for now
                             new Container
                             {
                                 Name = "Hit Objects",
                                 RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
-                                Child = HitObjectContainer
+                                Child = new Container
+                                {
+                                    Name = "Hit Objects",
+                                    RelativeSizeAxes = Axes.Both,
+                                    Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
+                                    Child = HitObjectContainer
+                                },
                             },
                         }
                     }
@@ -118,8 +121,8 @@ namespace osu.Game.Rulesets.Rush.UI
                 new FeverBar()
             };
 
-            AddNested(airLane);
-            AddNested(groundLane);
+            AddNested(AirLane);
+            AddNested(GroundLane);
             NewResult += onNewResult;
         }
 
@@ -170,7 +173,7 @@ namespace osu.Game.Rulesets.Rush.UI
             base.Add(hitObject);
         }
 
-        private LanePlayfield playfieldForLane(LanedHitLane lane) => lane == LanedHitLane.Air ? airLane : groundLane;
+        private LanePlayfield playfieldForLane(LanedHitLane lane) => lane == LanedHitLane.Air ? AirLane : GroundLane;
 
         private void onMiniBossAttacked(DrawableMiniBoss drawableMiniBoss, double timeOffset)
         {

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfieldCoveringWrapper.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfieldCoveringWrapper.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Rush.UI
+{
+    /// <summary>
+    /// A <see cref="Container"/> that has its contents partially hidden by an adjustable "cover". This is intended to be used in a playfield.
+    /// </summary>
+    public class PlayfieldCoveringWrapper : CompositeDrawable
+    {
+        /// <summary>
+        /// The complete cover, including gradient and fill.
+        /// </summary>
+        private readonly Drawable cover;
+
+        /// <summary>
+        /// The gradient portion of the cover.
+        /// </summary>
+        private readonly Box gradient;
+
+        /// <summary>
+        /// The fully-opaque portion of the cover.
+        /// </summary>
+        private readonly Box filled;
+
+        public PlayfieldCoveringWrapper(Drawable content)
+        {
+            InternalChild = new BufferedContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                Height = 2,
+                Children = new[]
+                {
+                    new Container{
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Height = 0.5f,
+                        Child = content,
+                    },
+                    cover = new Container
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        Blending = new BlendingParameters
+                        {
+                            // Don't change the destination colour.
+                            RGBEquation = BlendingEquation.Add,
+                            Source = BlendingType.Zero,
+                            Destination = BlendingType.One,
+                            // Subtract the cover's alpha from the destination (points with alpha 1 should make the destination completely transparent).
+                            AlphaEquation = BlendingEquation.Add,
+                            SourceAlpha = BlendingType.Zero,
+                            DestinationAlpha = BlendingType.OneMinusSrcAlpha
+                        },
+                        Children = new Drawable[]
+                        {
+                            gradient = new Box
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                RelativeSizeAxes = Axes.Both,
+                                RelativePositionAxes = Axes.Both,
+                                Width = 0.25f,
+                                Colour = ColourInfo.GradientHorizontal(
+                                    Color4.White.Opacity(1f),
+                                    Color4.White.Opacity(0f)
+                                )
+                            },
+                            filled = new Box
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                RelativeSizeAxes = Axes.Both,
+                                Width = 0
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+
+        /// <summary>
+        /// The relative area that should be completely covered. This does not include the fade.
+        /// </summary>
+        public float Coverage
+        {
+            set
+            {
+                filled.Width = value;
+                gradient.X = value;
+            }
+        }
+
+        /// <summary>
+        /// The direction in which the cover expands.
+        /// </summary>
+        public CoverExpandDirection Direction
+        {
+            set => cover.Scale = value == CoverExpandDirection.AlongScroll ? new Vector2(-1, 1) : Vector2.One;
+        }
+    }
+
+    public enum CoverExpandDirection
+    {
+        /// <summary>
+        /// The cover expands along the scrolling direction.
+        /// </summary>
+        AlongScroll,
+
+        /// <summary>
+        /// The cover expands against the scrolling direction.
+        /// </summary>
+        AgainstScroll
+    }
+}


### PR DESCRIPTION
Making a draft PR for visibility and feedback, will undraft when I fix some problems with it.

This is a direct port of Mania's visibility reduction mods to Rush, except horizontal. 

This is not quite complete yet, as it is currently very inefficient due to overlapping BufferedContainers. 
I'm looking at two potential resolutions, which involves either proxying the effects/judgements, so that they aren't drawn within the bufferedContainer (allowing a single cover to cover all HitObjectContainers); Or proxying the HitObjectDrawables out to a shared container. I'm prolly gonna take the latter option.

