### PR TITLE
Fix HitTargets animations having the wrong origin

### DIFF
--- a/osu.Game.Rulesets.Rush/UI/HitTarget.cs
+++ b/osu.Game.Rulesets.Rush/UI/HitTarget.cs
@@ -15,6 +15,8 @@ namespace osu.Game.Rulesets.Rush.UI
     {
         public HitTarget()
         {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
             Children = new Drawable[]
             {
                 new CircularContainer


### PR DESCRIPTION
Previously when beating, it scaled from the top-left corner rather than the centre. This fixes that.

<sub> This likely regressed in #150 </sub>