### PR TITLE
Switch to .NET 6

### DIFF
--- a/osu.Game.Rulesets.Rush.Tests/Visual/TestSceneTouchInputHandling.cs
+++ b/osu.Game.Rulesets.Rush.Tests/Visual/TestSceneTouchInputHandling.cs
@@ -10,7 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using osu.Game.Rulesets.Rush.Input;
-using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.HUD;
 using osu.Game.Tests.Visual;
 using osuTK;
 using osuTK.Graphics;
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Rush.Tests.Visual
                     Colour = Color4.Purple,
                     Alpha = 0.8f,
                 },
-                keyCounters = new KeyCounterDisplay
+                keyCounters = new DefaultKeyCounterDisplay()
                 {
                     Origin = Anchor.BottomRight,
                     Anchor = Anchor.BottomRight,

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -33,6 +33,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2022.1205.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2023.419.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
     <Configurations>Debug;Release;Development</Configurations>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <RootNamespace>osu.Game.Rulesets.Rush</RootNamespace>


### PR DESCRIPTION
Resolves build issues with current versions of osu!lazer as osu.Game (and others) now targets .NET Core 6.
As far as testing goes (tested on an iOS build with this ruleset + 2 other custom rulesets), no problems have arisen from this change.
Also bumps ppy.osu.Game to the latest release (2023.419.0) as of the time of writing.